### PR TITLE
Server Message size estimation

### DIFF
--- a/client/src/main/java/jake2/client/CL_ents.java
+++ b/client/src/main/java/jake2/client/CL_ents.java
@@ -28,7 +28,10 @@ package jake2.client;
 import jake2.qcommon.*;
 import jake2.qcommon.exec.Cvar;
 import jake2.qcommon.filesystem.FS;
-import jake2.qcommon.network.messages.server.*;
+import jake2.qcommon.network.messages.server.EntityUpdate;
+import jake2.qcommon.network.messages.server.FrameHeaderMessage;
+import jake2.qcommon.network.messages.server.PacketEntitiesMessage;
+import jake2.qcommon.network.messages.server.PlayerInfoMessage;
 import jake2.qcommon.util.Math3D;
 
 /**
@@ -221,52 +224,51 @@ public class CL_ents {
 		//
 		// parse the pmove_state_t
 		//
-		if (msg.pmType != null)
-			state.pmove.pm_type = msg.pmType;
+		if ((msg.deltaFlags & Defines.PS_M_TYPE) != 0)
+			state.pmove.pm_type = msg.currentState.pmove.pm_type;
 
 		if (ClientGlobals.cl.attractloop)
 			state.pmove.pm_type = Defines.PM_FREEZE; // demo playback
 
-		if (msg.pmOrigin != null)
-			state.pmove.origin = msg.pmOrigin;
-		if (msg.pmVelocity != null)
-			state.pmove.velocity = msg.pmVelocity;
-		if (msg.pmTime != null)
-			state.pmove.pm_time = msg.pmTime;
-		if (msg.pmFlags != null)
-			state.pmove.pm_flags = msg.pmFlags;
-		if (msg.pmGravity != null)
-			state.pmove.gravity = msg.pmGravity;
-		if (msg.pmDeltaAngles != null)
-			state.pmove.delta_angles = msg.pmDeltaAngles;
+		if ((msg.deltaFlags & Defines.PS_M_ORIGIN) != 0)
+			state.pmove.origin = msg.currentState.pmove.origin;
+		if ((msg.deltaFlags & Defines.PS_M_VELOCITY) != 0)
+			state.pmove.velocity = msg.currentState.pmove.velocity;
+		if ((msg.deltaFlags & Defines.PS_M_TIME) != 0)
+			state.pmove.pm_time = msg.currentState.pmove.pm_time;
+		if ((msg.deltaFlags & Defines.PS_M_FLAGS) != 0)
+			state.pmove.pm_flags = msg.currentState.pmove.pm_flags;
+		if ((msg.deltaFlags & Defines.PS_M_GRAVITY) != 0)
+			state.pmove.gravity = msg.currentState.pmove.gravity;
+		if ((msg.deltaFlags & Defines.PS_M_DELTA_ANGLES) != 0)
+			state.pmove.delta_angles = msg.currentState.pmove.delta_angles;
 		//
 		// parse the rest of the player_state_t
 		//
-		if (msg.viewOffset != null)
-			state.viewoffset = msg.viewOffset;
-		if (msg.viewAngles != null)
-			state.viewangles = msg.viewAngles;
-		if (msg.kickAngles != null)
-			state.kick_angles = msg.kickAngles;
-		if (msg.gunIndex != null)
-			state.gunindex = msg.gunIndex;
-		if (msg.gunFrame != null)
-			state.gunframe = msg.gunFrame;
-		if (msg.gunOffset != null)
-			state.gunoffset = msg.gunOffset;
-		if (msg.gunAngles != null)
-			state.gunangles = msg.gunAngles;
-		if (msg.blend != null)
-			state.blend = msg.blend;
-		if (msg.fov != null)
-			state.fov = msg.fov;
-		if (msg.rdFlags != null)
-			state.rdflags = msg.rdFlags;
+		if ((msg.deltaFlags & Defines.PS_VIEWOFFSET) != 0)
+			state.viewoffset = msg.currentState.viewoffset;
+		if ((msg.deltaFlags & Defines.PS_VIEWANGLES) != 0)
+			state.viewangles = msg.currentState.viewangles;
+		if ((msg.deltaFlags & Defines.PS_KICKANGLES) != 0)
+			state.kick_angles = msg.currentState.kick_angles;
+		if ((msg.deltaFlags & Defines.PS_WEAPONINDEX) != 0)
+			state.gunindex = msg.currentState.gunindex;
+		if ((msg.deltaFlags & Defines.PS_WEAPONFRAME) != 0) {
+			state.gunframe = msg.currentState.gunframe;
+			state.gunoffset = msg.currentState.gunoffset;
+			state.gunangles = msg.currentState.gunangles;
+		}
+		if ((msg.deltaFlags & Defines.PS_BLEND) != 0)
+			state.blend = msg.currentState.blend;
+		if ((msg.deltaFlags & Defines.PS_FOV) != 0)
+			state.fov = msg.currentState.fov;
+		if ((msg.deltaFlags & Defines.PS_RDFLAGS) != 0)
+			state.rdflags = msg.currentState.rdflags;
 
 		// copy only changed stats
 		for (int i = 0; i < Defines.MAX_STATS; i++) {
-			if ((msg.statsMask & (1 << i)) != 0) {
-				state.stats[i] = msg.stats[i];
+			if ((msg.statbits & (1 << i)) != 0) {
+				state.stats[i] = msg.currentState.stats[i];
 			}
 		}
 	}

--- a/info/Networking.md
+++ b/info/Networking.md
@@ -30,7 +30,7 @@ The following messages use delta compression:
  2. `PacketEntitiesMessage` (from server)
  3. `MoveMessage` (from client)
 
-The approach is the same for all of them - first identify what fields have changed (`flags`, like a bitmask), then sent only those fields.
+The approach is the same for all of them - first identify what fields have changed (`deltaFlags`, like a bitmask), then sent only those fields.
 
 ## Server Messages
 see package `jake2.qcommon.network.messages.server`

--- a/qcommon/src/main/java/jake2/qcommon/MSG.java
+++ b/qcommon/src/main/java/jake2/qcommon/MSG.java
@@ -149,193 +149,193 @@ public class MSG extends Globals {
     public static void WriteDeltaEntity(entity_state_t from, entity_state_t to,
             sizebuf_t msg, boolean force, boolean newentity) {
 
-        int flags = getFlags(from, to, newentity);
+        int deltaFlags = getDeltaFlags(from, to, newentity);
 
         //
         // write the message
         //
-        if (flags == 0 && !force)
+        if (deltaFlags == 0 && !force)
             return; // nothing to send!
 
-        WriteByte(msg, flags & 255);
+        WriteByte(msg, deltaFlags & 255);
 
-        if ((flags & 0xff000000) != 0) {
-            WriteByte(msg, (flags >>> 8) & 255);
-            WriteByte(msg, (flags >>> 16) & 255);
-            WriteByte(msg, (flags >>> 24) & 255);
-        } else if ((flags & 0x00ff0000) != 0) {
-            WriteByte(msg, (flags >>> 8) & 255);
-            WriteByte(msg, (flags >>> 16) & 255);
-        } else if ((flags & 0x0000ff00) != 0) {
-            WriteByte(msg, (flags >>> 8) & 255);
+        if ((deltaFlags & 0xff000000) != 0) {
+            WriteByte(msg, (deltaFlags >>> 8) & 255);
+            WriteByte(msg, (deltaFlags >>> 16) & 255);
+            WriteByte(msg, (deltaFlags >>> 24) & 255);
+        } else if ((deltaFlags & 0x00ff0000) != 0) {
+            WriteByte(msg, (deltaFlags >>> 8) & 255);
+            WriteByte(msg, (deltaFlags >>> 16) & 255);
+        } else if ((deltaFlags & 0x0000ff00) != 0) {
+            WriteByte(msg, (deltaFlags >>> 8) & 255);
         }
 
         //----------
 
-        if ((flags & U_NUMBER16) != 0)
+        if ((deltaFlags & U_NUMBER16) != 0)
             WriteShort(msg, to.number);
         else
             WriteByte(msg, to.number);
 
-        if ((flags & U_MODEL) != 0)
+        if ((deltaFlags & U_MODEL) != 0)
             WriteByte(msg, to.modelindex);
-        if ((flags & U_MODEL2) != 0)
+        if ((deltaFlags & U_MODEL2) != 0)
             WriteByte(msg, to.modelindex2);
-        if ((flags & U_MODEL3) != 0)
+        if ((deltaFlags & U_MODEL3) != 0)
             WriteByte(msg, to.modelindex3);
-        if ((flags & U_MODEL4) != 0)
+        if ((deltaFlags & U_MODEL4) != 0)
             WriteByte(msg, to.modelindex4);
 
-        if ((flags & U_FRAME8) != 0)
+        if ((deltaFlags & U_FRAME8) != 0)
             WriteByte(msg, to.frame);
-        if ((flags & U_FRAME16) != 0)
+        if ((deltaFlags & U_FRAME16) != 0)
             WriteShort(msg, to.frame);
 
-        if ((flags & U_SKIN8) != 0 && (flags & U_SKIN16) != 0) //used for laser
+        if ((deltaFlags & U_SKIN8) != 0 && (deltaFlags & U_SKIN16) != 0) //used for laser
                                                              // colors
             WriteInt(msg, to.skinnum);
-        else if ((flags & U_SKIN8) != 0)
+        else if ((deltaFlags & U_SKIN8) != 0)
             WriteByte(msg, to.skinnum);
-        else if ((flags & U_SKIN16) != 0)
+        else if ((deltaFlags & U_SKIN16) != 0)
             WriteShort(msg, to.skinnum);
 
-        if ((flags & (U_EFFECTS8 | U_EFFECTS16)) == (U_EFFECTS8 | U_EFFECTS16))
+        if ((deltaFlags & (U_EFFECTS8 | U_EFFECTS16)) == (U_EFFECTS8 | U_EFFECTS16))
             WriteInt(msg, to.effects);
-        else if ((flags & U_EFFECTS8) != 0)
+        else if ((deltaFlags & U_EFFECTS8) != 0)
             WriteByte(msg, to.effects);
-        else if ((flags & U_EFFECTS16) != 0)
+        else if ((deltaFlags & U_EFFECTS16) != 0)
             WriteShort(msg, to.effects);
 
-        if ((flags & (U_RENDERFX8 | U_RENDERFX16)) == (U_RENDERFX8 | U_RENDERFX16))
+        if ((deltaFlags & (U_RENDERFX8 | U_RENDERFX16)) == (U_RENDERFX8 | U_RENDERFX16))
             WriteInt(msg, to.renderfx);
-        else if ((flags & U_RENDERFX8) != 0)
+        else if ((deltaFlags & U_RENDERFX8) != 0)
             WriteByte(msg, to.renderfx);
-        else if ((flags & U_RENDERFX16) != 0)
+        else if ((deltaFlags & U_RENDERFX16) != 0)
             WriteShort(msg, to.renderfx);
 
-        if ((flags & U_ORIGIN1) != 0)
+        if ((deltaFlags & U_ORIGIN1) != 0)
             WriteCoord(msg, to.origin[0]);
-        if ((flags & U_ORIGIN2) != 0)
+        if ((deltaFlags & U_ORIGIN2) != 0)
             WriteCoord(msg, to.origin[1]);
-        if ((flags & U_ORIGIN3) != 0)
+        if ((deltaFlags & U_ORIGIN3) != 0)
             WriteCoord(msg, to.origin[2]);
 
-        if ((flags & U_ANGLE1) != 0)
+        if ((deltaFlags & U_ANGLE1) != 0)
             WriteAngle(msg, to.angles[0]);
-        if ((flags & U_ANGLE2) != 0)
+        if ((deltaFlags & U_ANGLE2) != 0)
             WriteAngle(msg, to.angles[1]);
-        if ((flags & U_ANGLE3) != 0)
+        if ((deltaFlags & U_ANGLE3) != 0)
             WriteAngle(msg, to.angles[2]);
 
-        if ((flags & U_OLDORIGIN) != 0) {
+        if ((deltaFlags & U_OLDORIGIN) != 0) {
             WriteCoord(msg, to.old_origin[0]);
             WriteCoord(msg, to.old_origin[1]);
             WriteCoord(msg, to.old_origin[2]);
         }
 
-        if ((flags & U_SOUND) != 0)
+        if ((deltaFlags & U_SOUND) != 0)
             WriteByte(msg, to.sound);
-        if ((flags & U_EVENT) != 0)
+        if ((deltaFlags & U_EVENT) != 0)
             WriteByte(msg, to.event);
-        if ((flags & U_SOLID) != 0)
+        if ((deltaFlags & U_SOLID) != 0)
             WriteShort(msg, to.solid);
     }
 
-    private static int getFlags(entity_state_t from, entity_state_t to, boolean newentity) {
+    private static int getDeltaFlags(entity_state_t from, entity_state_t to, boolean newentity) {
         if (0 == to.number)
             Com.Error(ERR_FATAL, "Unset entity number");
         if (to.number >= MAX_EDICTS)
             Com.Error(ERR_FATAL, "Entity number >= MAX_EDICTS");
 
         // send an update
-        int flags = 0;
+        int deltaFlags = 0;
 
         if (to.number >= 256)
-            flags |= U_NUMBER16; // number8 is implicit otherwise
+            deltaFlags |= U_NUMBER16; // number8 is implicit otherwise
 
         if (to.origin[0] != from.origin[0])
-            flags |= U_ORIGIN1;
+            deltaFlags |= U_ORIGIN1;
         if (to.origin[1] != from.origin[1])
-            flags |= U_ORIGIN2;
+            deltaFlags |= U_ORIGIN2;
         if (to.origin[2] != from.origin[2])
-            flags |= U_ORIGIN3;
+            deltaFlags |= U_ORIGIN3;
 
         if (to.angles[0] != from.angles[0])
-            flags |= U_ANGLE1;
+            deltaFlags |= U_ANGLE1;
         if (to.angles[1] != from.angles[1])
-            flags |= U_ANGLE2;
+            deltaFlags |= U_ANGLE2;
         if (to.angles[2] != from.angles[2])
-            flags |= U_ANGLE3;
+            deltaFlags |= U_ANGLE3;
 
         if (to.skinnum != from.skinnum) {
             if (to.skinnum < 256)
-                flags |= U_SKIN8;
+                deltaFlags |= U_SKIN8;
             else if (to.skinnum < 0x10000)
-                flags |= U_SKIN16;
+                deltaFlags |= U_SKIN16;
             else
-                flags |= (U_SKIN8 | U_SKIN16);
+                deltaFlags |= (U_SKIN8 | U_SKIN16);
         }
 
         if (to.frame != from.frame) {
             if (to.frame < 256)
-                flags |= U_FRAME8;
+                deltaFlags |= U_FRAME8;
             else
-                flags |= U_FRAME16;
+                deltaFlags |= U_FRAME16;
         }
 
         if (to.effects != from.effects) {
             if (to.effects < 256)
-                flags |= U_EFFECTS8;
+                deltaFlags |= U_EFFECTS8;
             else if (to.effects < 0x8000)
-                flags |= U_EFFECTS16;
+                deltaFlags |= U_EFFECTS16;
             else
-                flags |= U_EFFECTS8 | U_EFFECTS16;
+                deltaFlags |= U_EFFECTS8 | U_EFFECTS16;
         }
 
         if (to.renderfx != from.renderfx) {
             if (to.renderfx < 256)
-                flags |= U_RENDERFX8;
+                deltaFlags |= U_RENDERFX8;
             else if (to.renderfx < 0x8000)
-                flags |= U_RENDERFX16;
+                deltaFlags |= U_RENDERFX16;
             else
-                flags |= U_RENDERFX8 | U_RENDERFX16;
+                deltaFlags |= U_RENDERFX8 | U_RENDERFX16;
         }
 
         if (to.solid != from.solid)
-            flags |= U_SOLID;
+            deltaFlags |= U_SOLID;
 
         // event is not delta compressed, just 0 compressed
         if (to.event != 0)
-            flags |= U_EVENT;
+            deltaFlags |= U_EVENT;
 
         if (to.modelindex != from.modelindex)
-            flags |= U_MODEL;
+            deltaFlags |= U_MODEL;
         if (to.modelindex2 != from.modelindex2)
-            flags |= U_MODEL2;
+            deltaFlags |= U_MODEL2;
         if (to.modelindex3 != from.modelindex3)
-            flags |= U_MODEL3;
+            deltaFlags |= U_MODEL3;
         if (to.modelindex4 != from.modelindex4)
-            flags |= U_MODEL4;
+            deltaFlags |= U_MODEL4;
 
         if (to.sound != from.sound)
-            flags |= U_SOUND;
+            deltaFlags |= U_SOUND;
 
         if (newentity || (to.renderfx & RF_BEAM) != 0)
-            flags |= U_OLDORIGIN;
+            deltaFlags |= U_OLDORIGIN;
 
         //----------
 
-        if ((flags & 0xff000000) != 0)
-            flags |= U_MOREBITS3 | U_MOREBITS2 | U_MOREBITS1;
-        else if ((flags & 0x00ff0000) != 0)
-            flags |= U_MOREBITS2 | U_MOREBITS1;
-        else if ((flags & 0x0000ff00) != 0)
-            flags |= U_MOREBITS1;
-        return flags;
+        if ((deltaFlags & 0xff000000) != 0)
+            deltaFlags |= U_MOREBITS3 | U_MOREBITS2 | U_MOREBITS1;
+        else if ((deltaFlags & 0x00ff0000) != 0)
+            deltaFlags |= U_MOREBITS2 | U_MOREBITS1;
+        else if ((deltaFlags & 0x0000ff00) != 0)
+            deltaFlags |= U_MOREBITS1;
+        return deltaFlags;
     }
 
     public static int getDeltaSize(entity_state_t from, entity_state_t to, boolean newentity) {
-        int flags = getFlags(from, to, newentity);
+        int flags = getDeltaFlags(from, to, newentity);
         if (flags == 0)
             return 0;
 

--- a/qcommon/src/main/java/jake2/qcommon/entity_state_t.java
+++ b/qcommon/src/main/java/jake2/qcommon/entity_state_t.java
@@ -26,6 +26,7 @@ import jake2.qcommon.filesystem.QuakeFile;
 import jake2.qcommon.util.Math3D;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * entity_state_t is the information conveyed from the server
@@ -221,5 +222,70 @@ public class entity_state_t implements Cloneable
 		solid = 0;
 		sound = 0;
 		event = 0;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		entity_state_t that = (entity_state_t) o;
+
+		if (number != that.number) return false;
+		if (modelindex != that.modelindex) return false;
+		if (modelindex2 != that.modelindex2) return false;
+		if (modelindex3 != that.modelindex3) return false;
+		if (modelindex4 != that.modelindex4) return false;
+		if (frame != that.frame) return false;
+		if (skinnum != that.skinnum) return false;
+		if (effects != that.effects) return false;
+		if (renderfx != that.renderfx) return false;
+		if (solid != that.solid) return false;
+		if (sound != that.sound) return false;
+		if (event != that.event) return false;
+		if (!Arrays.equals(origin, that.origin)) return false;
+		if (!Arrays.equals(angles, that.angles)) return false;
+		return Arrays.equals(old_origin, that.old_origin);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = number;
+		result = 31 * result + Arrays.hashCode(origin);
+		result = 31 * result + Arrays.hashCode(angles);
+		result = 31 * result + Arrays.hashCode(old_origin);
+		result = 31 * result + modelindex;
+		result = 31 * result + modelindex2;
+		result = 31 * result + modelindex3;
+		result = 31 * result + modelindex4;
+		result = 31 * result + frame;
+		result = 31 * result + skinnum;
+		result = 31 * result + effects;
+		result = 31 * result + renderfx;
+		result = 31 * result + solid;
+		result = 31 * result + sound;
+		result = 31 * result + event;
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "entity_state_t{" +
+				"number=" + number +
+				", origin=" + Arrays.toString(origin) +
+				", angles=" + Arrays.toString(angles) +
+				", old_origin=" + Arrays.toString(old_origin) +
+				", modelindex=" + modelindex +
+				", modelindex2=" + modelindex2 +
+				", modelindex3=" + modelindex3 +
+				", modelindex4=" + modelindex4 +
+				", frame=" + frame +
+				", skinnum=" + skinnum +
+				", effects=" + effects +
+				", renderfx=" + renderfx +
+				", solid=" + solid +
+				", sound=" + sound +
+				", event=" + event +
+				'}';
 	}
 }

--- a/qcommon/src/main/java/jake2/qcommon/entity_state_t.java
+++ b/qcommon/src/main/java/jake2/qcommon/entity_state_t.java
@@ -227,7 +227,7 @@ public class entity_state_t implements Cloneable
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (!(o instanceof entity_state_t)) return false;
 
 		entity_state_t that = (entity_state_t) o;
 

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/NetworkPacket.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/NetworkPacket.java
@@ -3,7 +3,8 @@ package jake2.qcommon.network.messages;
 import jake2.qcommon.*;
 import jake2.qcommon.network.NetAddrType;
 import jake2.qcommon.network.messages.client.ClientMessage;
-import jake2.qcommon.network.messages.client.EndMessage;
+import jake2.qcommon.network.messages.client.EndOfClientPacketMessage;
+import jake2.qcommon.network.messages.server.EndOfServerPacketMessage;
 import jake2.qcommon.network.messages.server.ServerMessage;
 import jake2.qcommon.network.netadr_t;
 import jake2.qcommon.network.netchan_t;
@@ -94,7 +95,7 @@ public class NetworkPacket {
         List<ServerMessage> result = new ArrayList<>();
         while (true) {
             ServerMessage msg = ServerMessage.parseFromBuffer(buffer);
-            if (msg instanceof jake2.qcommon.network.messages.server.EndMessage) {
+            if (msg instanceof EndOfServerPacketMessage) {
                 break;
             } else if (msg != null) {
                 result.add(msg);
@@ -111,7 +112,7 @@ public class NetworkPacket {
         List<ClientMessage> result = new ArrayList<>();
         while (true) {
             ClientMessage msg = ClientMessage.parseFromBuffer(buffer, incomingSequence);
-            if (msg == null || msg instanceof EndMessage) {
+            if (msg == null || msg instanceof EndOfClientPacketMessage) {
                 break;
             } else {
                 result.add(msg);

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/client/ClientMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/client/ClientMessage.java
@@ -24,7 +24,7 @@ public abstract class ClientMessage {
         final ClientMessage msg;
         switch (type) {
             case CLC_BAD:
-                msg = new EndMessage();
+                msg = new EndOfClientPacketMessage();
                 break;
             case CLC_NOP:
                 // fixme: never sent by client directly

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/client/EndOfClientPacketMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/client/EndOfClientPacketMessage.java
@@ -2,8 +2,8 @@ package jake2.qcommon.network.messages.client;
 
 import jake2.qcommon.sizebuf_t;
 
-public class EndMessage extends ClientMessage {
-    protected EndMessage() {
+public class EndOfClientPacketMessage extends ClientMessage {
+    protected EndOfClientPacketMessage() {
         super(ClientMessageType.CLC_BAD);
     }
 

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/client/MoveMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/client/MoveMessage.java
@@ -78,43 +78,43 @@ public class MoveMessage extends ClientMessage {
         //
         // send the movement message
         //
-        int bits = 0;
+        int deltaFlags = 0;
         if (cmd.angles[0] != from.angles[0])
-            bits |= Defines.CM_ANGLE1;
+            deltaFlags |= Defines.CM_ANGLE1;
         if (cmd.angles[1] != from.angles[1])
-            bits |= Defines.CM_ANGLE2;
+            deltaFlags |= Defines.CM_ANGLE2;
         if (cmd.angles[2] != from.angles[2])
-            bits |= Defines.CM_ANGLE3;
+            deltaFlags |= Defines.CM_ANGLE3;
         if (cmd.forwardmove != from.forwardmove)
-            bits |= Defines.CM_FORWARD;
+            deltaFlags |= Defines.CM_FORWARD;
         if (cmd.sidemove != from.sidemove)
-            bits |= Defines.CM_SIDE;
+            deltaFlags |= Defines.CM_SIDE;
         if (cmd.upmove != from.upmove)
-            bits |= Defines.CM_UP;
+            deltaFlags |= Defines.CM_UP;
         if (cmd.buttons != from.buttons)
-            bits |= Defines.CM_BUTTONS;
+            deltaFlags |= Defines.CM_BUTTONS;
         if (cmd.impulse != from.impulse)
-            bits |= Defines.CM_IMPULSE;
+            deltaFlags |= Defines.CM_IMPULSE;
 
-        MSG.WriteByte(buf, bits);
+        MSG.WriteByte(buf, deltaFlags);
 
-        if ((bits & Defines.CM_ANGLE1) != 0)
+        if ((deltaFlags & Defines.CM_ANGLE1) != 0)
             MSG.WriteShort(buf, cmd.angles[0]);
-        if ((bits & Defines.CM_ANGLE2) != 0)
+        if ((deltaFlags & Defines.CM_ANGLE2) != 0)
             MSG.WriteShort(buf, cmd.angles[1]);
-        if ((bits & Defines.CM_ANGLE3) != 0)
+        if ((deltaFlags & Defines.CM_ANGLE3) != 0)
             MSG.WriteShort(buf, cmd.angles[2]);
 
-        if ((bits & Defines.CM_FORWARD) != 0)
+        if ((deltaFlags & Defines.CM_FORWARD) != 0)
             MSG.WriteShort(buf, cmd.forwardmove);
-        if ((bits & Defines.CM_SIDE) != 0)
+        if ((deltaFlags & Defines.CM_SIDE) != 0)
             MSG.WriteShort(buf, cmd.sidemove);
-        if ((bits & Defines.CM_UP) != 0)
+        if ((deltaFlags & Defines.CM_UP) != 0)
             MSG.WriteShort(buf, cmd.upmove);
 
-        if ((bits & Defines.CM_BUTTONS) != 0)
+        if ((deltaFlags & Defines.CM_BUTTONS) != 0)
             MSG.WriteByte(buf, cmd.buttons);
-        if ((bits & Defines.CM_IMPULSE) != 0)
+        if ((deltaFlags & Defines.CM_IMPULSE) != 0)
             MSG.WriteByte(buf, cmd.impulse);
 
         MSG.WriteByte(buf, cmd.msec);
@@ -123,29 +123,29 @@ public class MoveMessage extends ClientMessage {
 
     private static void readDeltaUserCommand(sizebuf_t buffer, usercmd_t from, usercmd_t move) {
         move.set(from);
-        int bits = MSG.ReadByte(buffer);
+        int deltaFlags = MSG.ReadByte(buffer);
 
         // read current angles
-        if ((bits & Defines.CM_ANGLE1) != 0)
+        if ((deltaFlags & Defines.CM_ANGLE1) != 0)
             move.angles[0] = MSG.ReadShort(buffer);
-        if ((bits & Defines.CM_ANGLE2) != 0)
+        if ((deltaFlags & Defines.CM_ANGLE2) != 0)
             move.angles[1] = MSG.ReadShort(buffer);
-        if ((bits & Defines.CM_ANGLE3) != 0)
+        if ((deltaFlags & Defines.CM_ANGLE3) != 0)
             move.angles[2] = MSG.ReadShort(buffer);
 
         // read movement
-        if ((bits & Defines.CM_FORWARD) != 0)
+        if ((deltaFlags & Defines.CM_FORWARD) != 0)
             move.forwardmove = MSG.ReadShort(buffer);
-        if ((bits & Defines.CM_SIDE) != 0)
+        if ((deltaFlags & Defines.CM_SIDE) != 0)
             move.sidemove = MSG.ReadShort(buffer);
-        if ((bits & Defines.CM_UP) != 0)
+        if ((deltaFlags & Defines.CM_UP) != 0)
             move.upmove = MSG.ReadShort(buffer);
 
         // read buttons
-        if ((bits & Defines.CM_BUTTONS) != 0)
+        if ((deltaFlags & Defines.CM_BUTTONS) != 0)
             move.buttons = (byte) MSG.ReadByte(buffer);
 
-        if ((bits & Defines.CM_IMPULSE) != 0)
+        if ((deltaFlags & Defines.CM_IMPULSE) != 0)
             move.impulse = (byte) MSG.ReadByte(buffer);
 
         // read time to run command

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/BeamOffsetTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/BeamOffsetTEMessage.java
@@ -3,6 +3,7 @@ package jake2.qcommon.network.messages.server;
 import jake2.qcommon.MSG;
 import jake2.qcommon.sizebuf_t;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 
@@ -43,5 +44,16 @@ public class BeamOffsetTEMessage extends BeamTEMessage {
     @Override
     int getSize() {
         return super.getSize() + 6;
+    }
+
+    @Override
+    public String toString() {
+        return "BeamOffsetTEMessage{" +
+                "offset=" + Arrays.toString(offset) +
+                ", ownerIndex=" + ownerIndex +
+                ", origin=" + Arrays.toString(origin) +
+                ", destination=" + Arrays.toString(destination) +
+                ", style=" + style +
+                '}';
     }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/BeamOffsetTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/BeamOffsetTEMessage.java
@@ -61,4 +61,22 @@ public class BeamOffsetTEMessage extends BeamTEMessage {
                 ", style=" + style +
                 '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        BeamOffsetTEMessage that = (BeamOffsetTEMessage) o;
+
+        return Arrays.equals(offset, that.offset);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + Arrays.hashCode(offset);
+        return result;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/BeamOffsetTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/BeamOffsetTEMessage.java
@@ -19,6 +19,14 @@ public class BeamOffsetTEMessage extends BeamTEMessage {
         super(style);
     }
 
+    public BeamOffsetTEMessage(int style, int ownerIndex, float[] origin, float[] destination, float[] offset) {
+        this(style);
+        this.ownerIndex = ownerIndex;
+        this.origin = origin;
+        this.destination = destination;
+        this.offset = offset;
+    }
+
     @Override
     protected void writeProperties(sizebuf_t buffer) {
         super.writeProperties(buffer);
@@ -30,5 +38,10 @@ public class BeamOffsetTEMessage extends BeamTEMessage {
         super.parse(buffer);
         offset = new float[3];
         MSG.ReadPos(buffer, offset);
+    }
+
+    @Override
+    int getSize() {
+        return super.getSize() + 6;
     }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/BeamOffsetTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/BeamOffsetTEMessage.java
@@ -47,6 +47,11 @@ public class BeamOffsetTEMessage extends BeamTEMessage {
     }
 
     @Override
+    Collection<Integer> getSupportedStyles() {
+        return SUBTYPES;
+    }
+
+    @Override
     public String toString() {
         return "BeamOffsetTEMessage{" +
                 "offset=" + Arrays.toString(offset) +

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/BeamTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/BeamTEMessage.java
@@ -3,6 +3,7 @@ package jake2.qcommon.network.messages.server;
 import jake2.qcommon.MSG;
 import jake2.qcommon.sizebuf_t;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 
@@ -50,5 +51,19 @@ public class BeamTEMessage extends TEMessage {
         MSG.ReadPos(buffer, origin);
         destination = new float[3];
         MSG.ReadPos(buffer, destination);
+    }
+
+    @Override
+    int getSize() {
+        return 2 + 2 + 2 * 2 * 3;
+    }
+
+    @Override
+    public String toString() {
+        return "BeamTEMessage{" +
+                "ownerIndex=" + ownerIndex +
+                ", origin=" + Arrays.toString(origin) +
+                ", destination=" + Arrays.toString(destination) +
+                '}';
     }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/BeamTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/BeamTEMessage.java
@@ -59,6 +59,11 @@ public class BeamTEMessage extends TEMessage {
     }
 
     @Override
+    Collection<Integer> getSupportedStyles() {
+        return SUBTYPES;
+    }
+
+    @Override
     public String toString() {
         return "BeamTEMessage{" +
                 "ownerIndex=" + ownerIndex +

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/BeamTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/BeamTEMessage.java
@@ -71,4 +71,24 @@ public class BeamTEMessage extends TEMessage {
                 ", destination=" + Arrays.toString(destination) +
                 '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        BeamTEMessage that = (BeamTEMessage) o;
+
+        if (ownerIndex != that.ownerIndex) return false;
+        if (!Arrays.equals(origin, that.origin)) return false;
+        return Arrays.equals(destination, that.destination);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = ownerIndex;
+        result = 31 * result + Arrays.hashCode(origin);
+        result = 31 * result + Arrays.hashCode(destination);
+        return result;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/ConfigStringMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/ConfigStringMessage.java
@@ -38,4 +38,22 @@ public class ConfigStringMessage extends ServerMessage {
     public String toString() {
         return "ConfigStringMessage{" + index + "=" + config + '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ConfigStringMessage that = (ConfigStringMessage) o;
+
+        if (index != that.index) return false;
+        return config != null ? config.equals(that.config) : that.config == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = index;
+        result = 31 * result + (config != null ? config.hashCode() : 0);
+        return result;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/ConfigStringMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/ConfigStringMessage.java
@@ -30,6 +30,11 @@ public class ConfigStringMessage extends ServerMessage {
     }
 
     @Override
+    int getSize() {
+        return 1 + 2 + config.length() + 1;
+    }
+
+    @Override
     public String toString() {
         return "ConfigStringMessage{" + index + "=" + config + '}';
     }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/DeltaEntityHeader.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/DeltaEntityHeader.java
@@ -8,4 +8,30 @@ public class DeltaEntityHeader {
         this.flags = flags;
         this.number = number;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DeltaEntityHeader that = (DeltaEntityHeader) o;
+
+        if (flags != that.flags) return false;
+        return number == that.number;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = flags;
+        result = 31 * result + number;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "DeltaEntityHeader{" +
+                "flags=" + flags +
+                ", number=" + number +
+                '}';
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/DisconnectMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/DisconnectMessage.java
@@ -16,4 +16,9 @@ public class DisconnectMessage extends ServerMessage {
     void parse(sizebuf_t buffer) {
         // no other fields
     }
+
+    @Override
+    int getSize() {
+        return 1;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/DisconnectMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/DisconnectMessage.java
@@ -26,4 +26,12 @@ public class DisconnectMessage extends ServerMessage {
     public String toString() {
         return "DisconnectMessage";
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null)
+            return false;
+        else
+            return this.getClass() == obj.getClass();
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/DisconnectMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/DisconnectMessage.java
@@ -21,4 +21,9 @@ public class DisconnectMessage extends ServerMessage {
     int getSize() {
         return 1;
     }
+
+    @Override
+    public String toString() {
+        return "DisconnectMessage";
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/DownloadMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/DownloadMessage.java
@@ -51,4 +51,11 @@ public class DownloadMessage extends ServerMessage {
         else
             return 4;
     }
+
+    @Override
+    public String toString() {
+        return "DownloadMessage{" +
+                "percentage=" + percentage +
+                '}';
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/DownloadMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/DownloadMessage.java
@@ -43,4 +43,12 @@ public class DownloadMessage extends ServerMessage {
             MSG.ReadData(buffer, data, size);
         }
     }
+
+    @Override
+    int getSize() {
+        if (data != null)
+            return 4 + data.length;
+        else
+            return 4;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/DownloadMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/DownloadMessage.java
@@ -4,6 +4,8 @@ import jake2.qcommon.MSG;
 import jake2.qcommon.SZ;
 import jake2.qcommon.sizebuf_t;
 
+import java.util.Arrays;
+
 /**
  * Transmits chunk of media (maps, skins, sounds, etc)
  */
@@ -57,5 +59,23 @@ public class DownloadMessage extends ServerMessage {
         return "DownloadMessage{" +
                 "percentage=" + percentage +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DownloadMessage that = (DownloadMessage) o;
+
+        if (percentage != that.percentage) return false;
+        return Arrays.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(data);
+        result = 31 * result + percentage;
+        return result;
     }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/EndMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/EndMessage.java
@@ -16,4 +16,9 @@ public class EndMessage extends ServerMessage {
     void parse(sizebuf_t buffer) {
 
     }
+
+    @Override
+    int getSize() {
+        return 1;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/EndOfServerPacketMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/EndOfServerPacketMessage.java
@@ -21,4 +21,9 @@ public class EndOfServerPacketMessage extends ServerMessage {
     int getSize() {
         return 1;
     }
+
+    @Override
+    public String toString() {
+        return "End";
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/EndOfServerPacketMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/EndOfServerPacketMessage.java
@@ -26,4 +26,13 @@ public class EndOfServerPacketMessage extends ServerMessage {
     public String toString() {
         return "End";
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null)
+            return false;
+        else
+            return this.getClass() == obj.getClass();
+    }
+
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/EndOfServerPacketMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/EndOfServerPacketMessage.java
@@ -2,8 +2,8 @@ package jake2.qcommon.network.messages.server;
 
 import jake2.qcommon.sizebuf_t;
 
-public class EndMessage extends ServerMessage {
-    public EndMessage() {
+public class EndOfServerPacketMessage extends ServerMessage {
+    public EndOfServerPacketMessage() {
         super(ServerMessageType.svc_end);
     }
 

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/EntityUpdate.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/EntityUpdate.java
@@ -44,6 +44,9 @@ public class EntityUpdate {
         this.isNewEntity = false;
     }
 
+    /**
+     * Compare headers if they exist in both objects
+     */
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -51,15 +54,9 @@ public class EntityUpdate {
 
         EntityUpdate that = (EntityUpdate) o;
 
-        if (header != null ? !header.equals(that.header) : that.header != null) return false;
-        return newState != null ? newState.equals(that.newState) : that.newState == null;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = header != null ? header.hashCode() : 0;
-        result = 31 * result + (newState != null ? newState.hashCode() : 0);
-        return result;
+        if (header != null && that.header != null)
+            return header.equals(that.header);
+        else return newState != null ? newState.equals(that.newState) : that.newState == null;
     }
 
     @Override

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/EntityUpdate.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/EntityUpdate.java
@@ -43,4 +43,30 @@ public class EntityUpdate {
         this.force = false;
         this.isNewEntity = false;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        EntityUpdate that = (EntityUpdate) o;
+
+        if (header != null ? !header.equals(that.header) : that.header != null) return false;
+        return newState != null ? newState.equals(that.newState) : that.newState == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = header != null ? header.hashCode() : 0;
+        result = 31 * result + (newState != null ? newState.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "EntityUpdate{" +
+                "header=" + header +
+                ", newState=" + newState +
+                '}';
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/FrameHeaderMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/FrameHeaderMessage.java
@@ -59,6 +59,11 @@ public class FrameHeaderMessage extends ServerMessage {
     }
 
     @Override
+    int getSize() {
+        return 1 + 10 + areaBitsLength;
+    }
+
+    @Override
     public String toString() {
         return "FrameMessage{" +
                 "frameNumber=" + frameNumber +

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/FrameHeaderMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/FrameHeaderMessage.java
@@ -73,4 +73,25 @@ public class FrameHeaderMessage extends ServerMessage {
                 ", areaBits=" + Arrays.toString(areaBits) +
                 '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        FrameHeaderMessage that = (FrameHeaderMessage) o;
+
+        if (frameNumber != that.frameNumber) return false;
+        if (lastFrame != that.lastFrame) return false;
+        if (suppressCount != that.suppressCount) return false;
+        if (areaBitsLength != that.areaBitsLength) return false;
+
+        // due to custom equals implementation - didn't bother with hashcode
+        for (int i = 0; i < areaBitsLength; i++) {
+            if (areaBits[i] != that.areaBits[i])
+                return false;
+        }
+        return true;
+    }
+
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/InventoryMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/InventoryMessage.java
@@ -50,4 +50,19 @@ public class InventoryMessage extends ServerMessage {
                 "inventory=" + Arrays.toString(inventory) +
                 '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        InventoryMessage that = (InventoryMessage) o;
+
+        return Arrays.equals(inventory, that.inventory);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(inventory);
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/InventoryMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/InventoryMessage.java
@@ -36,4 +36,9 @@ public class InventoryMessage extends ServerMessage {
             this.inventory[i] = MSG.ReadShort(buffer);
         }
     }
+
+    @Override
+    int getSize() {
+        return 1 + 2 * Defines.MAX_ITEMS;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/InventoryMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/InventoryMessage.java
@@ -4,6 +4,8 @@ import jake2.qcommon.Defines;
 import jake2.qcommon.MSG;
 import jake2.qcommon.sizebuf_t;
 
+import java.util.Arrays;
+
 /**
  * Inventory sent to client.
  * Holds information about how many specific items player holds.
@@ -40,5 +42,12 @@ public class InventoryMessage extends ServerMessage {
     @Override
     int getSize() {
         return 1 + 2 * Defines.MAX_ITEMS;
+    }
+
+    @Override
+    public String toString() {
+        return "InventoryMessage{" +
+                "inventory=" + Arrays.toString(inventory) +
+                '}';
     }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/LayoutMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/LayoutMessage.java
@@ -36,4 +36,19 @@ public class LayoutMessage extends ServerMessage {
                 "layout='" + layout + '\'' +
                 '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        LayoutMessage that = (LayoutMessage) o;
+
+        return layout != null ? layout.equals(that.layout) : that.layout == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return layout != null ? layout.hashCode() : 0;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/LayoutMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/LayoutMessage.java
@@ -24,4 +24,9 @@ public class LayoutMessage extends ServerMessage {
     void parse(sizebuf_t buffer) {
         this.layout = MSG.ReadString(buffer);
     }
+
+    @Override
+    int getSize() {
+        return 1 + layout.length() + 1;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/LayoutMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/LayoutMessage.java
@@ -29,4 +29,11 @@ public class LayoutMessage extends ServerMessage {
     int getSize() {
         return 1 + layout.length() + 1;
     }
+
+    @Override
+    public String toString() {
+        return "LayoutMessage{" +
+                "layout='" + layout + '\'' +
+                '}';
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/MuzzleFlash2Message.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/MuzzleFlash2Message.java
@@ -41,4 +41,22 @@ public class MuzzleFlash2Message extends ServerMessage {
                 ", flashType=" + flashType +
                 '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        MuzzleFlash2Message that = (MuzzleFlash2Message) o;
+
+        if (entityIndex != that.entityIndex) return false;
+        return flashType == that.flashType;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = entityIndex;
+        result = 31 * result + flashType;
+        return result;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/MuzzleFlash2Message.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/MuzzleFlash2Message.java
@@ -28,4 +28,9 @@ public class MuzzleFlash2Message extends ServerMessage {
         this.entityIndex = MSG.ReadShort(buffer);
         this.flashType = MSG.ReadByte(buffer);
     }
+
+    @Override
+    int getSize() {
+        return 4;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/MuzzleFlash2Message.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/MuzzleFlash2Message.java
@@ -33,4 +33,12 @@ public class MuzzleFlash2Message extends ServerMessage {
     int getSize() {
         return 4;
     }
+
+    @Override
+    public String toString() {
+        return "MuzzleFlash2Message{" +
+                "entityIndex=" + entityIndex +
+                ", flashType=" + flashType +
+                '}';
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/NopMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/NopMessage.java
@@ -17,4 +17,9 @@ public class NopMessage extends ServerMessage {
     void parse(sizebuf_t buffer) {
 
     }
+
+    @Override
+    int getSize() {
+        return 1;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/NopMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/NopMessage.java
@@ -22,4 +22,9 @@ public class NopMessage extends ServerMessage {
     int getSize() {
         return 1;
     }
+
+    @Override
+    public String toString() {
+        return "Nop";
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/NopMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/NopMessage.java
@@ -27,4 +27,13 @@ public class NopMessage extends ServerMessage {
     public String toString() {
         return "Nop";
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null)
+            return false;
+        else
+            return this.getClass() == obj.getClass();
+    }
+
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PacketEntitiesMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PacketEntitiesMessage.java
@@ -67,7 +67,49 @@ public class PacketEntitiesMessage extends ServerMessage {
 
     @Override
     int getSize() {
-        throw new UnsupportedOperationException("Not implemented");
+        return updates.stream().mapToInt(this::getUpdateSize).sum();
+    }
+
+    private int getUpdateSize(EntityUpdate value) {
+        if (value.header == null) {
+            // entity is changed
+            return 3 + MSG.getDeltaSize(value.oldState, value.newState, value.isNewEntity);
+        } else {
+            // entity is removed
+            int result = 2;
+            if ((value.header.flags & 0x0000ff00) != 0)
+                result += 1;
+
+            if ((value.header.flags & Defines.U_NUMBER16) != 0)
+                result += 2;
+            else
+                result += 1;
+
+            result += 2;
+            return result;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PacketEntitiesMessage)) return false;
+
+        PacketEntitiesMessage that = (PacketEntitiesMessage) o;
+
+        return updates != null ? updates.equals(that.updates) : that.updates == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return updates != null ? updates.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "PacketEntitiesMessage{" +
+                "updates=" + updates +
+                '}';
     }
 }
 

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PacketEntitiesMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PacketEntitiesMessage.java
@@ -64,5 +64,10 @@ public class PacketEntitiesMessage extends ServerMessage {
             }
         }
     }
+
+    @Override
+    int getSize() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
 }
 

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PacketEntitiesMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PacketEntitiesMessage.java
@@ -67,16 +67,16 @@ public class PacketEntitiesMessage extends ServerMessage {
 
     @Override
     int getSize() {
-        return updates.stream().mapToInt(this::getUpdateSize).sum();
+        return 1 + updates.stream().mapToInt(this::getUpdateSize).sum() + 2;
     }
 
     private int getUpdateSize(EntityUpdate value) {
         if (value.header == null) {
             // entity is changed
-            return 3 + MSG.getDeltaSize(value.oldState, value.newState, value.isNewEntity);
+            return MSG.getDeltaSize(value.oldState, value.newState, value.isNewEntity);
         } else {
             // entity is removed
-            int result = 2;
+            int result = 1;
             if ((value.header.flags & 0x0000ff00) != 0)
                 result += 1;
 
@@ -85,7 +85,6 @@ public class PacketEntitiesMessage extends ServerMessage {
             else
                 result += 1;
 
-            result += 2;
             return result;
         }
     }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PlayerInfoMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PlayerInfoMessage.java
@@ -340,13 +340,15 @@ public class PlayerInfoMessage extends ServerMessage {
 
     @Override
     public String toString() {
-        return "PlayerInfoMessage";
+        return "PlayerInfoMessage{" +
+                "currentState=" + currentState +
+                '}';
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof PlayerInfoMessage)) return false;
 
         PlayerInfoMessage that = (PlayerInfoMessage) o;
 

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PlayerInfoMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PlayerInfoMessage.java
@@ -2,236 +2,339 @@ package jake2.qcommon.network.messages.server;
 
 import jake2.qcommon.Defines;
 import jake2.qcommon.MSG;
+import jake2.qcommon.player_state_t;
 import jake2.qcommon.sizebuf_t;
 
 public class PlayerInfoMessage extends ServerMessage {
+    private player_state_t previousState;
     // determine what needs to be sent
-    public int messageFlags;
-    public Integer pmType = null;
-    public short[] pmOrigin = null;
-    public short[] pmVelocity = null;
-    public Byte pmTime = null;
-    public Byte pmFlags = null;
-    public Short pmGravity = null;
-    public short[] pmDeltaAngles = null;
-    public float[] viewOffset = null;
-    public float[] viewAngles = null;
-    public float[] kickAngles = null;
-    public Integer gunIndex = null;
-    public Integer gunFrame = null;
-    public float[] gunOffset = null;
-    public float[] gunAngles = null;
-    public float[] blend = null;
-    public Float fov = null;
-    public Integer rdFlags = null;
-    public Integer statsMask = null;
-    public short[] stats = null;
+    public int deltaFlags;
+    public int statbits;
+    public player_state_t currentState;
 
     public PlayerInfoMessage() {
         super(ServerMessageType.svc_playerinfo);
     }
 
-    public PlayerInfoMessage(int messageFlags, int pmType, short[] pmOrigin, short[] pmVelocity, byte pmTime, byte pmFlags, short pmGravity, short[] pmDeltaAngles, float[] viewOffset, float[] viewAngles, float[] kickAngles, int gunIndex, int gunFrame, float[] gunOffset, float[] gunAngles, float[] blend, float fov, int rdFlags, int statsMask, short[] stats) {
+    public PlayerInfoMessage(player_state_t previousState, player_state_t currentState) {
         this();
-        this.messageFlags = messageFlags;
-        this.pmType = pmType;
-        this.pmOrigin = pmOrigin;
-        this.pmVelocity = pmVelocity;
-        this.pmTime = pmTime;
-        this.pmFlags = pmFlags;
-        this.pmGravity = pmGravity;
-        this.pmDeltaAngles = pmDeltaAngles;
-        this.viewOffset = viewOffset;
-        this.viewAngles = viewAngles;
-        this.kickAngles = kickAngles;
-        this.gunIndex = gunIndex;
-        this.gunFrame = gunFrame;
-        this.gunOffset = gunOffset;
-        this.gunAngles = gunAngles;
-        this.blend = blend;
-        this.fov = fov;
-        this.rdFlags = rdFlags;
-        this.statsMask = statsMask;
-        this.stats = stats;
+        this.previousState = previousState;
+        this.currentState = currentState;
     }
 
+    // determine what needs to be sent
+    private void computeDeltaFlags() {
+        if (currentState.pmove.pm_type != previousState.pmove.pm_type)
+            deltaFlags |= Defines.PS_M_TYPE;
+
+        if (currentState.pmove.origin[0] != previousState.pmove.origin[0]
+                || currentState.pmove.origin[1] != previousState.pmove.origin[1]
+                || currentState.pmove.origin[2] != previousState.pmove.origin[2])
+            deltaFlags |= Defines.PS_M_ORIGIN;
+
+        if (currentState.pmove.velocity[0] != previousState.pmove.velocity[0]
+                || currentState.pmove.velocity[1] != previousState.pmove.velocity[1]
+                || currentState.pmove.velocity[2] != previousState.pmove.velocity[2])
+            deltaFlags |= Defines.PS_M_VELOCITY;
+
+        if (currentState.pmove.pm_time != previousState.pmove.pm_time)
+            deltaFlags |= Defines.PS_M_TIME;
+
+        if (currentState.pmove.pm_flags != previousState.pmove.pm_flags)
+            deltaFlags |= Defines.PS_M_FLAGS;
+
+        if (currentState.pmove.gravity != previousState.pmove.gravity)
+            deltaFlags |= Defines.PS_M_GRAVITY;
+
+        if (currentState.pmove.delta_angles[0] != previousState.pmove.delta_angles[0]
+                || currentState.pmove.delta_angles[1] != previousState.pmove.delta_angles[1]
+                || currentState.pmove.delta_angles[2] != previousState.pmove.delta_angles[2])
+            deltaFlags |= Defines.PS_M_DELTA_ANGLES;
+
+        if (currentState.viewoffset[0] != previousState.viewoffset[0]
+                || currentState.viewoffset[1] != previousState.viewoffset[1]
+                || currentState.viewoffset[2] != previousState.viewoffset[2])
+            deltaFlags |= Defines.PS_VIEWOFFSET;
+
+        if (currentState.viewangles[0] != previousState.viewangles[0]
+                || currentState.viewangles[1] != previousState.viewangles[1]
+                || currentState.viewangles[2] != previousState.viewangles[2])
+            deltaFlags |= Defines.PS_VIEWANGLES;
+
+        if (currentState.kick_angles[0] != previousState.kick_angles[0]
+                || currentState.kick_angles[1] != previousState.kick_angles[1]
+                || currentState.kick_angles[2] != previousState.kick_angles[2])
+            deltaFlags |= Defines.PS_KICKANGLES;
+
+        if (currentState.blend[0] != previousState.blend[0] || currentState.blend[1] != previousState.blend[1]
+                || currentState.blend[2] != previousState.blend[2] || currentState.blend[3] != previousState.blend[3])
+            deltaFlags |= Defines.PS_BLEND;
+
+        if (currentState.fov != previousState.fov)
+            deltaFlags |= Defines.PS_FOV;
+
+        // always sent?
+        deltaFlags |= Defines.PS_WEAPONINDEX;
+
+        if (currentState.gunframe != previousState.gunframe)
+            deltaFlags |= Defines.PS_WEAPONFRAME;
+
+        if (currentState.rdflags != previousState.rdflags)
+            deltaFlags |= Defines.PS_RDFLAGS;
+
+        for (int i = 0; i < Defines.MAX_STATS; i++) {
+            if (currentState.stats[i] != previousState.stats[i]) {
+                statbits |= 1 << i;
+            }
+        }
+    }
 
     @Override
     protected void writeProperties(sizebuf_t buffer) {
-        MSG.WriteShort(buffer, messageFlags);
+        computeDeltaFlags();
+        MSG.WriteShort(buffer, deltaFlags);
 
         // write the pmove_state_t
-        if ((messageFlags & Defines.PS_M_TYPE) != 0)
-            MSG.WriteByte(buffer, pmType);
+        if ((deltaFlags & Defines.PS_M_TYPE) != 0)
+            MSG.WriteByte(buffer, currentState.pmove.pm_type);
 
-        if ((messageFlags & Defines.PS_M_ORIGIN) != 0) {
-            MSG.WriteShort(buffer, pmOrigin[0]);
-            MSG.WriteShort(buffer, pmOrigin[1]);
-            MSG.WriteShort(buffer, pmOrigin[2]);
+        if ((deltaFlags & Defines.PS_M_ORIGIN) != 0) {
+            MSG.WriteShort(buffer, currentState.pmove.origin[0]);
+            MSG.WriteShort(buffer, currentState.pmove.origin[1]);
+            MSG.WriteShort(buffer, currentState.pmove.origin[2]);
         }
 
-        if ((messageFlags & Defines.PS_M_VELOCITY) != 0) {
-            MSG.WriteShort(buffer, pmVelocity[0]);
-            MSG.WriteShort(buffer, pmVelocity[1]);
-            MSG.WriteShort(buffer, pmVelocity[2]);
+        if ((deltaFlags & Defines.PS_M_VELOCITY) != 0) {
+            MSG.WriteShort(buffer, currentState.pmove.velocity[0]);
+            MSG.WriteShort(buffer, currentState.pmove.velocity[1]);
+            MSG.WriteShort(buffer, currentState.pmove.velocity[2]);
         }
 
-        if ((messageFlags & Defines.PS_M_TIME) != 0)
-            MSG.WriteByte(buffer, pmTime);
+        if ((deltaFlags & Defines.PS_M_TIME) != 0)
+            MSG.WriteByte(buffer, currentState.pmove.pm_time);
 
-        if ((messageFlags & Defines.PS_M_FLAGS) != 0)
-            MSG.WriteByte(buffer, pmFlags);
+        if ((deltaFlags & Defines.PS_M_FLAGS) != 0)
+            MSG.WriteByte(buffer, currentState.pmove.pm_flags);
 
-        if ((messageFlags & Defines.PS_M_GRAVITY) != 0)
-            MSG.WriteShort(buffer, pmGravity);
+        if ((deltaFlags & Defines.PS_M_GRAVITY) != 0)
+            MSG.WriteShort(buffer, currentState.pmove.gravity);
 
-        if ((messageFlags & Defines.PS_M_DELTA_ANGLES) != 0) {
-            MSG.WriteShort(buffer, pmDeltaAngles[0]);
-            MSG.WriteShort(buffer, pmDeltaAngles[1]);
-            MSG.WriteShort(buffer, pmDeltaAngles[2]);
+        if ((deltaFlags & Defines.PS_M_DELTA_ANGLES) != 0) {
+            MSG.WriteShort(buffer, currentState.pmove.delta_angles[0]);
+            MSG.WriteShort(buffer, currentState.pmove.delta_angles[1]);
+            MSG.WriteShort(buffer, currentState.pmove.delta_angles[2]);
         }
 
         // write the rest of the player_state_t
-        if ((messageFlags & Defines.PS_VIEWOFFSET) != 0) {
-            MSG.WriteChar(buffer, viewOffset[0] * 4);
-            MSG.WriteChar(buffer, viewOffset[1] * 4);
-            MSG.WriteChar(buffer, viewOffset[2] * 4);
+        if ((deltaFlags & Defines.PS_VIEWOFFSET) != 0) {
+            MSG.WriteChar(buffer, currentState.viewoffset[0] * 4);
+            MSG.WriteChar(buffer, currentState.viewoffset[1] * 4);
+            MSG.WriteChar(buffer, currentState.viewoffset[2] * 4);
         }
 
-        if ((messageFlags & Defines.PS_VIEWANGLES) != 0) {
-            MSG.WriteAngle16(buffer, viewAngles[0]);
-            MSG.WriteAngle16(buffer, viewAngles[1]);
-            MSG.WriteAngle16(buffer, viewAngles[2]);
+        if ((deltaFlags & Defines.PS_VIEWANGLES) != 0) {
+            MSG.WriteAngle16(buffer, currentState.viewangles[0]);
+            MSG.WriteAngle16(buffer, currentState.viewangles[1]);
+            MSG.WriteAngle16(buffer, currentState.viewangles[2]);
         }
 
-        if ((messageFlags & Defines.PS_KICKANGLES) != 0) {
-            MSG.WriteChar(buffer, kickAngles[0] * 4);
-            MSG.WriteChar(buffer, kickAngles[1] * 4);
-            MSG.WriteChar(buffer, kickAngles[2] * 4);
+        if ((deltaFlags & Defines.PS_KICKANGLES) != 0) {
+            MSG.WriteChar(buffer, currentState.kick_angles[0] * 4);
+            MSG.WriteChar(buffer, currentState.kick_angles[1] * 4);
+            MSG.WriteChar(buffer, currentState.kick_angles[2] * 4);
         }
 
-        if ((messageFlags & Defines.PS_WEAPONINDEX) != 0) {
-            MSG.WriteByte(buffer, gunIndex);
+        if ((deltaFlags & Defines.PS_WEAPONINDEX) != 0) {
+            MSG.WriteByte(buffer, currentState.gunindex);
         }
 
-        if ((messageFlags & Defines.PS_WEAPONFRAME) != 0) {
-            MSG.WriteByte(buffer, gunFrame);
-            MSG.WriteChar(buffer, gunOffset[0] * 4);
-            MSG.WriteChar(buffer, gunOffset[1] * 4);
-            MSG.WriteChar(buffer, gunOffset[2] * 4);
-            MSG.WriteChar(buffer, gunAngles[0] * 4);
-            MSG.WriteChar(buffer, gunAngles[1] * 4);
-            MSG.WriteChar(buffer, gunAngles[2] * 4);
+        if ((deltaFlags & Defines.PS_WEAPONFRAME) != 0) {
+            MSG.WriteByte(buffer, currentState.gunframe);
+            MSG.WriteChar(buffer, currentState.gunoffset[0] * 4);
+            MSG.WriteChar(buffer, currentState.gunoffset[1] * 4);
+            MSG.WriteChar(buffer, currentState.gunoffset[2] * 4);
+            MSG.WriteChar(buffer, currentState.gunangles[0] * 4);
+            MSG.WriteChar(buffer, currentState.gunangles[1] * 4);
+            MSG.WriteChar(buffer, currentState.gunangles[2] * 4);
         }
 
-        if ((messageFlags & Defines.PS_BLEND) != 0) {
-            MSG.WriteByte(buffer, blend[0] * 255);
-            MSG.WriteByte(buffer, blend[1] * 255);
-            MSG.WriteByte(buffer, blend[2] * 255);
-            MSG.WriteByte(buffer, blend[3] * 255);
+        if ((deltaFlags & Defines.PS_BLEND) != 0) {
+            MSG.WriteByte(buffer, currentState.blend[0] * 255);
+            MSG.WriteByte(buffer, currentState.blend[1] * 255);
+            MSG.WriteByte(buffer, currentState.blend[2] * 255);
+            MSG.WriteByte(buffer, currentState.blend[3] * 255);
         }
-        if ((messageFlags & Defines.PS_FOV) != 0)
-            MSG.WriteByte(buffer, fov);
-        if ((messageFlags & Defines.PS_RDFLAGS) != 0)
-            MSG.WriteByte(buffer, rdFlags);
+        if ((deltaFlags & Defines.PS_FOV) != 0)
+            MSG.WriteByte(buffer, currentState.fov);
 
-        MSG.WriteLong(buffer, statsMask);
+        if ((deltaFlags & Defines.PS_RDFLAGS) != 0)
+            MSG.WriteByte(buffer, currentState.rdflags);
+
+        MSG.WriteLong(buffer, statbits);
         for (int i = 0; i < Defines.MAX_STATS; i++) {
-            if ((statsMask & (1 << i)) != 0)
-                MSG.WriteShort(buffer, stats[i]);
+            if ((statbits & (1 << i)) != 0)
+                MSG.WriteShort(buffer, currentState.stats[i]);
         }
     }
 
     @Override
     void parse(sizebuf_t buffer) {
-        this.messageFlags = MSG.ReadShort(buffer);
-        if ((messageFlags & Defines.PS_M_TYPE) != 0) {
-            this.pmType = MSG.ReadByte(buffer);
+        this.deltaFlags = MSG.ReadShort(buffer);
+        this.currentState = new player_state_t();
+        if ((deltaFlags & Defines.PS_M_TYPE) != 0) {
+            this.currentState.pmove.pm_type = MSG.ReadByte(buffer);
         }
-        if ((messageFlags & Defines.PS_M_ORIGIN) != 0) {
-            this.pmOrigin = new short[3];
-            this.pmOrigin[0] = MSG.ReadShort(buffer);
-            this.pmOrigin[1] = MSG.ReadShort(buffer);
-            this.pmOrigin[2] = MSG.ReadShort(buffer);
+        if ((deltaFlags & Defines.PS_M_ORIGIN) != 0) {
+            this.currentState.pmove.origin = new short[3];
+            this.currentState.pmove.origin[0] = MSG.ReadShort(buffer);
+            this.currentState.pmove.origin[1] = MSG.ReadShort(buffer);
+            this.currentState.pmove.origin[2] = MSG.ReadShort(buffer);
         }
-        if ((messageFlags & Defines.PS_M_VELOCITY) != 0) {
-            this.pmVelocity = new short[3];
-            this.pmVelocity[0] = MSG.ReadShort(buffer);
-            this.pmVelocity[1] = MSG.ReadShort(buffer);
-            this.pmVelocity[2] = MSG.ReadShort(buffer);
+        if ((deltaFlags & Defines.PS_M_VELOCITY) != 0) {
+            this.currentState.pmove.velocity = new short[3];
+            this.currentState.pmove.velocity[0] = MSG.ReadShort(buffer);
+            this.currentState.pmove.velocity[1] = MSG.ReadShort(buffer);
+            this.currentState.pmove.velocity[2] = MSG.ReadShort(buffer);
         }
-        if ((messageFlags & Defines.PS_M_TIME) != 0) {
-            this.pmTime = (byte) MSG.ReadByte(buffer);
+        if ((deltaFlags & Defines.PS_M_TIME) != 0) {
+            this.currentState.pmove.pm_time = (byte) MSG.ReadByte(buffer);
         }
-        if ((messageFlags & Defines.PS_M_FLAGS) != 0) {
-            this.pmFlags = (byte) MSG.ReadByte(buffer);
+        if ((deltaFlags & Defines.PS_M_FLAGS) != 0) {
+            this.currentState.pmove.pm_flags = (byte) MSG.ReadByte(buffer);
         }
-        if ((messageFlags & Defines.PS_M_GRAVITY) != 0) {
-            this.pmGravity = MSG.ReadShort(buffer);
+        if ((deltaFlags & Defines.PS_M_GRAVITY) != 0) {
+            this.currentState.pmove.gravity = MSG.ReadShort(buffer);
         }
-        if ((messageFlags & Defines.PS_M_DELTA_ANGLES) != 0) {
-            this.pmDeltaAngles = new short[3];
-            this.pmDeltaAngles[0] = MSG.ReadShort(buffer);
-            this.pmDeltaAngles[1] = MSG.ReadShort(buffer);
-            this.pmDeltaAngles[2] = MSG.ReadShort(buffer);
+        if ((deltaFlags & Defines.PS_M_DELTA_ANGLES) != 0) {
+            this.currentState.pmove.delta_angles = new short[3];
+            this.currentState.pmove.delta_angles[0] = MSG.ReadShort(buffer);
+            this.currentState.pmove.delta_angles[1] = MSG.ReadShort(buffer);
+            this.currentState.pmove.delta_angles[2] = MSG.ReadShort(buffer);
         }
-        if ((messageFlags & Defines.PS_VIEWOFFSET) != 0) {
-            this.viewOffset = new float[3];
-            this.viewOffset[0] = MSG.ReadChar(buffer) * 0.25f;
-            this.viewOffset[1] = MSG.ReadChar(buffer) * 0.25f;
-            this.viewOffset[2] = MSG.ReadChar(buffer) * 0.25f;
+        if ((deltaFlags & Defines.PS_VIEWOFFSET) != 0) {
+            this.currentState.viewoffset = new float[3];
+            this.currentState.viewoffset[0] = MSG.ReadChar(buffer) * 0.25f;
+            this.currentState.viewoffset[1] = MSG.ReadChar(buffer) * 0.25f;
+            this.currentState.viewoffset[2] = MSG.ReadChar(buffer) * 0.25f;
         }
-        if ((messageFlags & Defines.PS_VIEWANGLES) != 0) {
-            this.viewAngles = new float[3];
-            this.viewAngles[0] = MSG.ReadAngle16(buffer);
-            this.viewAngles[1] = MSG.ReadAngle16(buffer);
-            this.viewAngles[2] = MSG.ReadAngle16(buffer);
+        if ((deltaFlags & Defines.PS_VIEWANGLES) != 0) {
+            this.currentState.viewangles = new float[3];
+            this.currentState.viewangles[0] = MSG.ReadAngle16(buffer);
+            this.currentState.viewangles[1] = MSG.ReadAngle16(buffer);
+            this.currentState.viewangles[2] = MSG.ReadAngle16(buffer);
         }
-        if ((messageFlags & Defines.PS_KICKANGLES) != 0) {
-            this.kickAngles = new float[3];
-            this.kickAngles[0] = MSG.ReadChar(buffer) * 0.25f;
-            this.kickAngles[1] = MSG.ReadChar(buffer) * 0.25f;
-            this.kickAngles[2] = MSG.ReadChar(buffer) * 0.25f;
+        if ((deltaFlags & Defines.PS_KICKANGLES) != 0) {
+            this.currentState.kick_angles = new float[3];
+            this.currentState.kick_angles[0] = MSG.ReadChar(buffer) * 0.25f;
+            this.currentState.kick_angles[1] = MSG.ReadChar(buffer) * 0.25f;
+            this.currentState.kick_angles[2] = MSG.ReadChar(buffer) * 0.25f;
         }
-        if ((messageFlags & Defines.PS_WEAPONINDEX) != 0) {
-            this.gunIndex = MSG.ReadByte(buffer);
+        if ((deltaFlags & Defines.PS_WEAPONINDEX) != 0) {
+            this.currentState.gunindex = MSG.ReadByte(buffer);
         }
-        if ((messageFlags & Defines.PS_WEAPONFRAME) != 0) {
-            this.gunFrame = MSG.ReadByte(buffer);
-            this.gunOffset = new float[3];
-            this.gunOffset[0] = MSG.ReadChar(buffer) * 0.25f;
-            this.gunOffset[1] = MSG.ReadChar(buffer) * 0.25f;
-            this.gunOffset[2] = MSG.ReadChar(buffer) * 0.25f;
-            this.gunAngles = new float[3];
-            this.gunAngles[0] = MSG.ReadChar(buffer) * 0.25f;
-            this.gunAngles[1] = MSG.ReadChar(buffer) * 0.25f;
-            this.gunAngles[2] = MSG.ReadChar(buffer) * 0.25f;
+        if ((deltaFlags & Defines.PS_WEAPONFRAME) != 0) {
+            this.currentState.gunframe = MSG.ReadByte(buffer);
+            this.currentState.gunoffset = new float[3];
+            this.currentState.gunoffset[0] = MSG.ReadChar(buffer) * 0.25f;
+            this.currentState.gunoffset[1] = MSG.ReadChar(buffer) * 0.25f;
+            this.currentState.gunoffset[2] = MSG.ReadChar(buffer) * 0.25f;
+            this.currentState.gunangles = new float[3];
+            this.currentState.gunangles[0] = MSG.ReadChar(buffer) * 0.25f;
+            this.currentState.gunangles[1] = MSG.ReadChar(buffer) * 0.25f;
+            this.currentState.gunangles[2] = MSG.ReadChar(buffer) * 0.25f;
         }
-        if ((messageFlags & Defines.PS_BLEND) != 0) {
-            this.blend = new float[4];
-            this.blend[0] = MSG.ReadByte(buffer) / 255.0f;
-            this.blend[1] = MSG.ReadByte(buffer) / 255.0f;
-            this.blend[2] = MSG.ReadByte(buffer) / 255.0f;
-            this.blend[3] = MSG.ReadByte(buffer) / 255.0f;
+        if ((deltaFlags & Defines.PS_BLEND) != 0) {
+            this.currentState.blend = new float[4];
+            this.currentState.blend[0] = MSG.ReadByte(buffer) / 255.0f;
+            this.currentState.blend[1] = MSG.ReadByte(buffer) / 255.0f;
+            this.currentState.blend[2] = MSG.ReadByte(buffer) / 255.0f;
+            this.currentState.blend[3] = MSG.ReadByte(buffer) / 255.0f;
         }
-        if ((messageFlags & Defines.PS_FOV) != 0) {
-            this.fov = (float) MSG.ReadByte(buffer);
+        if ((deltaFlags & Defines.PS_FOV) != 0) {
+            this.currentState.fov = (float) MSG.ReadByte(buffer);
         }
-        if ((messageFlags & Defines.PS_RDFLAGS) != 0) {
-            this.rdFlags = MSG.ReadByte(buffer);
+        if ((deltaFlags & Defines.PS_RDFLAGS) != 0) {
+            this.currentState.rdflags = MSG.ReadByte(buffer);
         }
         // parse stats
-        this.statsMask = MSG.ReadLong(buffer);
-        this.stats = new short[Defines.MAX_STATS];
+        statbits = MSG.ReadLong(buffer);
+        this.currentState.stats = new short[Defines.MAX_STATS];
         for (int i = 0; i < Defines.MAX_STATS; i++) {
-            if ((statsMask & (1 << i)) != 0) {
-                this.stats[i] = MSG.ReadShort(buffer);
+            if ((statbits & (1 << i)) != 0) {
+                this.currentState.stats[i] = MSG.ReadShort(buffer);
             }
         }
     }
 
     @Override
     int getSize() {
-        return -1;
+        computeDeltaFlags();
+        int result = 3;
+
+        // write the pmove_state_t
+        if ((deltaFlags & Defines.PS_M_TYPE) != 0) {
+            result += 1;
+        }
+
+        if ((deltaFlags & Defines.PS_M_ORIGIN) != 0) {
+            result += 6;
+        }
+
+        if ((deltaFlags & Defines.PS_M_VELOCITY) != 0) {
+            result += 6;
+        }
+
+        if ((deltaFlags & Defines.PS_M_TIME) != 0)
+            result += 1;
+
+        if ((deltaFlags & Defines.PS_M_FLAGS) != 0)
+            result += 1;
+
+        if ((deltaFlags & Defines.PS_M_GRAVITY) != 0)
+            result += 2;
+
+        if ((deltaFlags & Defines.PS_M_DELTA_ANGLES) != 0) {
+            result += 6;
+        }
+
+        // write the rest of the player_state_t
+        if ((deltaFlags & Defines.PS_VIEWOFFSET) != 0) {
+            result += 3;
+        }
+
+        if ((deltaFlags & Defines.PS_VIEWANGLES) != 0) {
+            result += 6;
+        }
+
+        if ((deltaFlags & Defines.PS_KICKANGLES) != 0) {
+            result += 3;
+        }
+
+        if ((deltaFlags & Defines.PS_WEAPONINDEX) != 0) {
+            result += 1;
+        }
+
+        if ((deltaFlags & Defines.PS_WEAPONFRAME) != 0) {
+            result += 7;
+        }
+
+        if ((deltaFlags & Defines.PS_BLEND) != 0) {
+            result += 4;
+        }
+
+        if ((deltaFlags & Defines.PS_FOV) != 0) {
+            result += 1;
+        }
+
+        if ((deltaFlags & Defines.PS_RDFLAGS) != 0) {
+            result += 1;
+        }
+
+        result += 4;
+        for (int i = 0; i < Defines.MAX_STATS; i++) {
+            if ((statbits & (1 << i)) != 0)
+                result += 2;
+        }
+        return result;
     }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PlayerInfoMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PlayerInfoMessage.java
@@ -229,4 +229,9 @@ public class PlayerInfoMessage extends ServerMessage {
             }
         }
     }
+
+    @Override
+    int getSize() {
+        return -1;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PlayerInfoMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PlayerInfoMessage.java
@@ -337,4 +337,24 @@ public class PlayerInfoMessage extends ServerMessage {
         }
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "PlayerInfoMessage";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PlayerInfoMessage that = (PlayerInfoMessage) o;
+
+        return currentState != null ? currentState.equals(that.currentState) : that.currentState == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return currentState != null ? currentState.hashCode() : 0;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PointDirectionTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PointDirectionTEMessage.java
@@ -3,6 +3,7 @@ package jake2.qcommon.network.messages.server;
 import jake2.qcommon.MSG;
 import jake2.qcommon.sizebuf_t;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 
@@ -55,5 +56,14 @@ public class PointDirectionTEMessage extends PointTEMessage {
     @Override
     int getSize() {
         return super.getSize() + 1;
+    }
+
+    @Override
+    public String toString() {
+        return "PointDirectionTEMessage{" +
+                "direction=" + Arrays.toString(direction) +
+                ", position=" + Arrays.toString(position) +
+                ", style=" + style +
+                '}';
     }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PointDirectionTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PointDirectionTEMessage.java
@@ -59,6 +59,11 @@ public class PointDirectionTEMessage extends PointTEMessage {
     }
 
     @Override
+    Collection<Integer> getSupportedStyles() {
+        return SUBTYPES;
+    }
+
+    @Override
     public String toString() {
         return "PointDirectionTEMessage{" +
                 "direction=" + Arrays.toString(direction) +

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PointDirectionTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PointDirectionTEMessage.java
@@ -71,4 +71,22 @@ public class PointDirectionTEMessage extends PointTEMessage {
                 ", style=" + style +
                 '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        PointDirectionTEMessage that = (PointDirectionTEMessage) o;
+
+        return Arrays.equals(direction, that.direction);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + Arrays.hashCode(direction);
+        return result;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PointDirectionTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PointDirectionTEMessage.java
@@ -51,4 +51,9 @@ public class PointDirectionTEMessage extends PointTEMessage {
         this.direction = new float[3];
         MSG.ReadDir(buffer, direction);
     }
+
+    @Override
+    int getSize() {
+        return super.getSize() + 1;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PointTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PointTEMessage.java
@@ -91,4 +91,19 @@ public class PointTEMessage extends TEMessage {
                 "position=" + Arrays.toString(position) +
                 '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PointTEMessage that = (PointTEMessage) o;
+
+        return Arrays.equals(position, that.position);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(position);
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PointTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PointTEMessage.java
@@ -81,6 +81,11 @@ public class PointTEMessage extends TEMessage {
     }
 
     @Override
+    Collection<Integer> getSupportedStyles() {
+        return SUBTYPES;
+    }
+
+    @Override
     public String toString() {
         return "PointTEMessage{" +
                 "position=" + Arrays.toString(position) +

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PointTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PointTEMessage.java
@@ -3,6 +3,7 @@ package jake2.qcommon.network.messages.server;
 import jake2.qcommon.MSG;
 import jake2.qcommon.sizebuf_t;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 
@@ -72,5 +73,17 @@ public class PointTEMessage extends TEMessage {
     void parse(sizebuf_t buffer) {
         this.position = new float[3];
         MSG.ReadPos(buffer, position);
+    }
+
+    @Override
+    int getSize() {
+        return 8;
+    }
+
+    @Override
+    public String toString() {
+        return "PointTEMessage{" +
+                "position=" + Arrays.toString(position) +
+                '}';
     }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PrintCenterMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PrintCenterMessage.java
@@ -30,6 +30,11 @@ public class PrintCenterMessage extends ServerMessage {
     }
 
     @Override
+    int getSize() {
+        return 1 + text.length() + 1;
+    }
+
+    @Override
     public String toString() {
         return "PrintCenterMessage{" + text + '}';
     }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PrintCenterMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PrintCenterMessage.java
@@ -39,4 +39,18 @@ public class PrintCenterMessage extends ServerMessage {
         return "PrintCenterMessage{" + text + '}';
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PrintCenterMessage that = (PrintCenterMessage) o;
+
+        return text != null ? text.equals(that.text) : that.text == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return text != null ? text.hashCode() : 0;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PrintMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PrintMessage.java
@@ -35,6 +35,11 @@ public class PrintMessage extends ServerMessage {
     }
 
     @Override
+    int getSize() {
+        return 2 + text.length() + 1;
+    }
+
+    @Override
     public String toString() {
         return "PrintMessage{" + level + "=" + text + '}';
     }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/PrintMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/PrintMessage.java
@@ -43,4 +43,22 @@ public class PrintMessage extends ServerMessage {
     public String toString() {
         return "PrintMessage{" + level + "=" + text + '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PrintMessage that = (PrintMessage) o;
+
+        if (level != that.level) return false;
+        return text != null ? text.equals(that.text) : that.text == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = level;
+        result = 31 * result + (text != null ? text.hashCode() : 0);
+        return result;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/ReconnectMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/ReconnectMessage.java
@@ -21,4 +21,9 @@ public class ReconnectMessage extends ServerMessage {
     int getSize() {
         return 1;
     }
+
+    @Override
+    public String toString() {
+        return "ReconnectMessage";
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/ReconnectMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/ReconnectMessage.java
@@ -26,4 +26,13 @@ public class ReconnectMessage extends ServerMessage {
     public String toString() {
         return "ReconnectMessage";
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null)
+            return false;
+        else
+            return this.getClass() == obj.getClass();
+    }
+
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/ReconnectMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/ReconnectMessage.java
@@ -16,4 +16,9 @@ public class ReconnectMessage extends ServerMessage {
     void parse(sizebuf_t buffer) {
 
     }
+
+    @Override
+    int getSize() {
+        return 1;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/ServerDataMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/ServerDataMessage.java
@@ -50,4 +50,9 @@ public class ServerDataMessage extends ServerMessage {
         this.playerNumber = MSG.ReadShort(buffer);
         this.levelString = MSG.ReadString(buffer);
     }
+
+    @Override
+    int getSize() {
+        return 1 + 4 + 4 + 1 + gameName.length() + 1 + 2 + levelString.length() + 1;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/ServerDataMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/ServerDataMessage.java
@@ -67,4 +67,30 @@ public class ServerDataMessage extends ServerMessage {
                 ", levelString='" + levelString + '\'' +
                 '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ServerDataMessage that = (ServerDataMessage) o;
+
+        if (protocol != that.protocol) return false;
+        if (spawnCount != that.spawnCount) return false;
+        if (demo != that.demo) return false;
+        if (playerNumber != that.playerNumber) return false;
+        if (gameName != null ? !gameName.equals(that.gameName) : that.gameName != null) return false;
+        return levelString != null ? levelString.equals(that.levelString) : that.levelString == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = protocol;
+        result = 31 * result + spawnCount;
+        result = 31 * result + (demo ? 1 : 0);
+        result = 31 * result + (gameName != null ? gameName.hashCode() : 0);
+        result = 31 * result + playerNumber;
+        result = 31 * result + (levelString != null ? levelString.hashCode() : 0);
+        return result;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/ServerDataMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/ServerDataMessage.java
@@ -55,4 +55,16 @@ public class ServerDataMessage extends ServerMessage {
     int getSize() {
         return 1 + 4 + 4 + 1 + gameName.length() + 1 + 2 + levelString.length() + 1;
     }
+
+    @Override
+    public String toString() {
+        return "ServerDataMessage{" +
+                "protocol=" + protocol +
+                ", spawnCount=" + spawnCount +
+                ", demo=" + demo +
+                ", gameName='" + gameName + '\'' +
+                ", playerNumber=" + playerNumber +
+                ", levelString='" + levelString + '\'' +
+                '}';
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/ServerMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/ServerMessage.java
@@ -123,6 +123,11 @@ public abstract class ServerMessage {
 
     abstract void parse(sizebuf_t buffer);
 
+    /**
+     * @return size of the message in bytes
+     */
+    abstract int getSize();
+
     public static ServerMessage parseFromBuffer(sizebuf_t buffer) {
 
         final int cmd = MSG.ReadByte(buffer);

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/ServerMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/ServerMessage.java
@@ -132,7 +132,7 @@ public abstract class ServerMessage {
 
         final int cmd = MSG.ReadByte(buffer);
         if (cmd == -1)
-            return new EndMessage();
+            return new EndOfServerPacketMessage();
         ServerMessageType type = ServerMessageType.fromInt(cmd);
         final ServerMessage msg;
         // skip parsing of messages not yet migrated to the ServerMessage class

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/SoundMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/SoundMessage.java
@@ -5,6 +5,8 @@ import jake2.qcommon.Defines;
 import jake2.qcommon.MSG;
 import jake2.qcommon.sizebuf_t;
 
+import java.util.Arrays;
+
 /**
  * Each entity can have eight independent sound sources, like voice,
  * weapon, feet, etc.
@@ -122,6 +124,65 @@ public class SoundMessage extends ServerMessage {
 
     @Override
     int getSize() {
-        return -1;
+        int result = 3;
+        if ((flags & Defines.SND_VOLUME) != 0)
+            result += 1;
+
+        if ((flags & Defines.SND_ATTENUATION) != 0)
+            result += 1;
+
+        if ((flags & Defines.SND_OFFSET) != 0)
+            result += 1;
+        if ((flags & Defines.SND_ENT) != 0) { // entity reletive
+            result += 2;
+        }
+        if ((flags & Defines.SND_POS) != 0) { // positioned in space
+            result += 6;
+        }
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SoundMessage that = (SoundMessage) o;
+
+        if (flags != that.flags) return false;
+        if (soundIndex != that.soundIndex) return false;
+        if (Float.compare(that.volume, volume) != 0) return false;
+        if (Float.compare(that.attenuation, attenuation) != 0) return false;
+        if (Float.compare(that.timeOffset, timeOffset) != 0) return false;
+        if (sendchan != that.sendchan) return false;
+        if (entityIndex != that.entityIndex) return false;
+        return Arrays.equals(origin, that.origin);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = flags;
+        result = 31 * result + soundIndex;
+        result = 31 * result + (volume != +0.0f ? Float.floatToIntBits(volume) : 0);
+        result = 31 * result + (attenuation != +0.0f ? Float.floatToIntBits(attenuation) : 0);
+        result = 31 * result + (timeOffset != +0.0f ? Float.floatToIntBits(timeOffset) : 0);
+        result = 31 * result + sendchan;
+        result = 31 * result + Arrays.hashCode(origin);
+        result = 31 * result + entityIndex;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "SoundMessage{" +
+                "flags=" + flags +
+                ", soundIndex=" + soundIndex +
+                ", volume=" + volume +
+                ", attenuation=" + attenuation +
+                ", timeOffset=" + timeOffset +
+                ", sendchan=" + sendchan +
+                ", origin=" + Arrays.toString(origin) +
+                ", entityIndex=" + entityIndex +
+                '}';
     }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/SoundMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/SoundMessage.java
@@ -119,4 +119,9 @@ public class SoundMessage extends ServerMessage {
             origin = null;
 
     }
+
+    @Override
+    int getSize() {
+        return -1;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/SpawnBaselineMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/SpawnBaselineMessage.java
@@ -26,7 +26,6 @@ public class SpawnBaselineMessage extends ServerMessage {
 
     @Override
     protected void writeProperties(sizebuf_t buffer) {
-
         MSG.WriteDeltaEntity(base, entityState, buffer, true, true);
     }
 
@@ -44,7 +43,22 @@ public class SpawnBaselineMessage extends ServerMessage {
     @Override
     public String toString() {
         return "SpawnBaselineMessage{" +
-                "entityState.number=" + entityState.number +
-                "}";
+                "entityState=" + entityState +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SpawnBaselineMessage that = (SpawnBaselineMessage) o;
+
+        return entityState != null ? entityState.equals(that.entityState) : that.entityState == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return entityState != null ? entityState.hashCode() : 0;
     }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/SpawnBaselineMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/SpawnBaselineMessage.java
@@ -49,8 +49,10 @@ public class SpawnBaselineMessage extends ServerMessage {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof SpawnBaselineMessage))
+            return false;
 
         SpawnBaselineMessage that = (SpawnBaselineMessage) o;
 

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/SpawnBaselineMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/SpawnBaselineMessage.java
@@ -13,6 +13,7 @@ import jake2.qcommon.sizebuf_t;
 public class SpawnBaselineMessage extends ServerMessage {
 
     public entity_state_t entityState;
+    private final entity_state_t base = new entity_state_t(null);;
 
     public SpawnBaselineMessage() {
         super(ServerMessageType.svc_spawnbaseline);
@@ -25,7 +26,8 @@ public class SpawnBaselineMessage extends ServerMessage {
 
     @Override
     protected void writeProperties(sizebuf_t buffer) {
-        MSG.WriteDeltaEntity(new entity_state_t(null), entityState, buffer, true, true);
+
+        MSG.WriteDeltaEntity(base, entityState, buffer, true, true);
     }
 
     @Override
@@ -36,6 +38,13 @@ public class SpawnBaselineMessage extends ServerMessage {
 
     @Override
     int getSize() {
-        return -1;
+        return 1 + MSG.getDeltaSize(base, entityState, true);
+    }
+
+    @Override
+    public String toString() {
+        return "SpawnBaselineMessage{" +
+                "entityState.number=" + entityState.number +
+                "}";
     }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/SpawnBaselineMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/SpawnBaselineMessage.java
@@ -33,4 +33,9 @@ public class SpawnBaselineMessage extends ServerMessage {
         DeltaEntityHeader header = parseDeltaEntityHeader(buffer);
         entityState = parseEntityState(header.number, header.flags, buffer);
     }
+
+    @Override
+    int getSize() {
+        return -1;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/SplashTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/SplashTEMessage.java
@@ -46,7 +46,6 @@ public class SplashTEMessage extends TEMessage {
 
     @Override
     void parse(sizebuf_t buffer) {
-        super.parse(buffer);
         count = MSG.ReadByte(buffer);
         position = new float[3];
         MSG.ReadPos(buffer, position);

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/SplashTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/SplashTEMessage.java
@@ -3,6 +3,7 @@ package jake2.qcommon.network.messages.server;
 import jake2.qcommon.MSG;
 import jake2.qcommon.sizebuf_t;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 
@@ -52,5 +53,20 @@ public class SplashTEMessage extends TEMessage {
         direction = new float[3];
         MSG.ReadDir(buffer, direction);
         param = MSG.ReadByte(buffer);
+    }
+
+    @Override
+    int getSize() {
+        return 2 + 1 + 6 + 1 + 1 ;
+    }
+
+    @Override
+    public String toString() {
+        return "SplashTEMessage{" +
+                "count=" + count +
+                ", position=" + Arrays.toString(position) +
+                ", direction=" + Arrays.toString(direction) +
+                ", param=" + param +
+                '}';
     }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/SplashTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/SplashTEMessage.java
@@ -60,6 +60,11 @@ public class SplashTEMessage extends TEMessage {
     }
 
     @Override
+    Collection<Integer> getSupportedStyles() {
+        return SUBTYPES;
+    }
+
+    @Override
     public String toString() {
         return "SplashTEMessage{" +
                 "count=" + count +

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/SplashTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/SplashTEMessage.java
@@ -73,4 +73,26 @@ public class SplashTEMessage extends TEMessage {
                 ", param=" + param +
                 '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SplashTEMessage that = (SplashTEMessage) o;
+
+        if (count != that.count) return false;
+        if (param != that.param) return false;
+        if (!Arrays.equals(position, that.position)) return false;
+        return Arrays.equals(direction, that.direction);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = count;
+        result = 31 * result + Arrays.hashCode(position);
+        result = 31 * result + Arrays.hashCode(direction);
+        result = 31 * result + param;
+        return result;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/StuffTextMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/StuffTextMessage.java
@@ -28,6 +28,11 @@ public class StuffTextMessage extends ServerMessage {
     }
 
     @Override
+    int getSize() {
+        return 1 + text.length() + 1;
+    }
+
+    @Override
     public String toString() {
         return "StuffTextMessage{" + text + '}';
     }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/StuffTextMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/StuffTextMessage.java
@@ -15,12 +15,12 @@ public class StuffTextMessage extends ServerMessage {
 
     public StuffTextMessage(String text) {
         this();
-        this.text = text;
+        this.text = text + "\n";
     }
 
     @Override
     protected void writeProperties(sizebuf_t buffer) {
-        MSG.WriteString(buffer, text + "\n");
+        MSG.WriteString(buffer, text);
     }
 
     @Override
@@ -30,12 +30,27 @@ public class StuffTextMessage extends ServerMessage {
 
     @Override
     int getSize() {
-        return 1 + text.length() + 1 + 1;
+        return 1 + text.length() + 1;
     }
 
     @Override
     public String toString() {
         return "StuffTextMessage{" + text + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        StuffTextMessage that = (StuffTextMessage) o;
+
+        return text != null ? text.equals(that.text) : that.text == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return text != null ? text.hashCode() : 0;
     }
 }
 

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/StuffTextMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/StuffTextMessage.java
@@ -2,6 +2,7 @@ package jake2.qcommon.network.messages.server;
 
 import jake2.qcommon.MSG;
 import jake2.qcommon.sizebuf_t;
+
 /**
  * Sent to client stuffed into client's console buffer, \n terminated
  */
@@ -29,7 +30,7 @@ public class StuffTextMessage extends ServerMessage {
 
     @Override
     int getSize() {
-        return 1 + text.length() + 1;
+        return 1 + text.length() + 1 + 1;
     }
 
     @Override

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/TEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/TEMessage.java
@@ -3,6 +3,8 @@ package jake2.qcommon.network.messages.server;
 import jake2.qcommon.MSG;
 import jake2.qcommon.sizebuf_t;
 
+import java.util.Collection;
+
 /**
  * Temp entity
  */
@@ -12,7 +14,7 @@ public abstract class TEMessage extends ServerMessage {
         this.style = style;
     }
 
-    public final int style;
+    public int style;
 
     @Override
     protected void writeProperties(sizebuf_t buffer) {
@@ -21,7 +23,7 @@ public abstract class TEMessage extends ServerMessage {
 
     @Override
     void parse(sizebuf_t buffer) {
-
+        this.style = MSG.ReadByte(buffer);
     }
 
     @Override
@@ -34,5 +36,11 @@ public abstract class TEMessage extends ServerMessage {
         return "TEMessage{" +
                 "style=" + style +
                 '}';
+    }
+
+    protected void validateStyle(int style, Collection<Integer> supported) {
+        if (!supported.contains(style)) {
+            throw new IllegalArgumentException("Wrong style for temp entity: " + style + " for class: " + this.getClass().getSimpleName());
+        }
     }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/TEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/TEMessage.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 public abstract class TEMessage extends ServerMessage {
     public TEMessage(int style) {
         super(ServerMessageType.svc_temp_entity);
+        validateStyle(style);
         this.style = style;
     }
 
@@ -27,19 +28,16 @@ public abstract class TEMessage extends ServerMessage {
     }
 
     @Override
-    int getSize() {
-        throw new IllegalStateException("Not implemented");
-    }
-
-    @Override
     public String toString() {
         return "TEMessage{" +
                 "style=" + style +
                 '}';
     }
 
-    protected void validateStyle(int style, Collection<Integer> supported) {
-        if (!supported.contains(style)) {
+    abstract Collection<Integer> getSupportedStyles();
+
+    protected final void validateStyle(int style) {
+        if (!getSupportedStyles().contains(style)) {
             throw new IllegalArgumentException("Wrong style for temp entity: " + style + " for class: " + this.getClass().getSimpleName());
         }
     }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/TEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/TEMessage.java
@@ -28,4 +28,11 @@ public abstract class TEMessage extends ServerMessage {
     int getSize() {
         throw new IllegalStateException("Not implemented");
     }
+
+    @Override
+    public String toString() {
+        return "TEMessage{" +
+                "style=" + style +
+                '}';
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/TEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/TEMessage.java
@@ -23,4 +23,9 @@ public abstract class TEMessage extends ServerMessage {
     void parse(sizebuf_t buffer) {
 
     }
+
+    @Override
+    int getSize() {
+        throw new IllegalStateException("Not implemented");
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/TrailTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/TrailTEMessage.java
@@ -49,6 +49,11 @@ public class TrailTEMessage extends PointTEMessage {
     }
 
     @Override
+    Collection<Integer> getSupportedStyles() {
+        return SUBTYPES;
+    }
+
+    @Override
     public String toString() {
         return "TrailTEMessage{" +
                 "position=" + Arrays.toString(position) +

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/TrailTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/TrailTEMessage.java
@@ -61,4 +61,22 @@ public class TrailTEMessage extends PointTEMessage {
                 ", destination=" + Arrays.toString(destination) +
                 '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        TrailTEMessage that = (TrailTEMessage) o;
+
+        return Arrays.equals(destination, that.destination);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + Arrays.hashCode(destination);
+        return result;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/TrailTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/TrailTEMessage.java
@@ -3,6 +3,7 @@ package jake2.qcommon.network.messages.server;
 import jake2.qcommon.MSG;
 import jake2.qcommon.sizebuf_t;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 
@@ -45,5 +46,14 @@ public class TrailTEMessage extends PointTEMessage {
     @Override
     int getSize() {
         return super.getSize() + 6;
+    }
+
+    @Override
+    public String toString() {
+        return "TrailTEMessage{" +
+                "position=" + Arrays.toString(position) +
+                ", style=" + style +
+                ", destination=" + Arrays.toString(destination) +
+                '}';
     }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/TrailTEMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/TrailTEMessage.java
@@ -41,4 +41,9 @@ public class TrailTEMessage extends PointTEMessage {
         this.destination = new float[3];
         MSG.ReadPos(buffer, destination);
     }
+
+    @Override
+    int getSize() {
+        return super.getSize() + 6;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/WeaponSoundMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/WeaponSoundMessage.java
@@ -38,4 +38,12 @@ public class WeaponSoundMessage extends ServerMessage {
     int getSize() {
         return 4;
     }
+
+    @Override
+    public String toString() {
+        return "WeaponSoundMessage{" +
+                "entityIndex=" + entityIndex +
+                ", type=" + type +
+                '}';
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/WeaponSoundMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/WeaponSoundMessage.java
@@ -46,4 +46,22 @@ public class WeaponSoundMessage extends ServerMessage {
                 ", type=" + type +
                 '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        WeaponSoundMessage that = (WeaponSoundMessage) o;
+
+        if (entityIndex != that.entityIndex) return false;
+        return type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = entityIndex;
+        result = 31 * result + type;
+        return result;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/WeaponSoundMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/WeaponSoundMessage.java
@@ -33,4 +33,9 @@ public class WeaponSoundMessage extends ServerMessage {
         this.entityIndex = MSG.ReadShort(buffer);
         this.type = MSG.ReadByte(buffer);
     }
+
+    @Override
+    int getSize() {
+        return 4;
+    }
 }

--- a/qcommon/src/main/java/jake2/qcommon/player_state_t.java
+++ b/qcommon/src/main/java/jake2/qcommon/player_state_t.java
@@ -180,7 +180,7 @@ public class player_state_t {
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (!(o instanceof player_state_t)) return false;
 
 		player_state_t that = (player_state_t) o;
 

--- a/qcommon/src/main/java/jake2/qcommon/player_state_t.java
+++ b/qcommon/src/main/java/jake2/qcommon/player_state_t.java
@@ -22,11 +22,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 package jake2.qcommon;
 
-import jake2.qcommon.util.Lib;
 import jake2.qcommon.util.Math3D;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.util.Arrays;
 
 /** 
  	Player_state_t is the information needed in addition to pmove_state_t
@@ -177,26 +177,59 @@ public class player_state_t {
 			f.writeShort(stats[n]);
 	}
 
-	/** Prints the player state. */
-	public void dump() {
-		pmove.dump();
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
 
-		Lib.printv("viewangles", viewangles);
-		Lib.printv("viewoffset", viewoffset);
-		Lib.printv("kick_angles", kick_angles);
-		Lib.printv("gunangles", gunangles);
-		Lib.printv("gunoffset", gunoffset);
+		player_state_t that = (player_state_t) o;
 
-		Com.Println("gunindex: " + gunindex);
-		Com.Println("gunframe: " + gunframe);
+		if (gunindex != that.gunindex) return false;
+		if (gunframe != that.gunframe) return false;
+		if (Float.compare(that.fov, fov) != 0) return false;
+		if (rdflags != that.rdflags) return false;
+		if (pmove != null ? !pmove.equals(that.pmove) : that.pmove != null) return false;
+		if (!Arrays.equals(viewangles, that.viewangles)) return false;
+		if (!Arrays.equals(viewoffset, that.viewoffset)) return false;
+		if (!Arrays.equals(kick_angles, that.kick_angles)) return false;
+		if (!Arrays.equals(gunangles, that.gunangles)) return false;
+		if (!Arrays.equals(gunoffset, that.gunoffset)) return false;
+		if (!Arrays.equals(blend, that.blend)) return false;
+		return Arrays.equals(stats, that.stats);
+	}
 
-		Lib.printv("blend", blend);
+	@Override
+	public int hashCode() {
+		int result = pmove != null ? pmove.hashCode() : 0;
+		result = 31 * result + Arrays.hashCode(viewangles);
+		result = 31 * result + Arrays.hashCode(viewoffset);
+		result = 31 * result + Arrays.hashCode(kick_angles);
+		result = 31 * result + Arrays.hashCode(gunangles);
+		result = 31 * result + Arrays.hashCode(gunoffset);
+		result = 31 * result + gunindex;
+		result = 31 * result + gunframe;
+		result = 31 * result + Arrays.hashCode(blend);
+		result = 31 * result + (fov != +0.0f ? Float.floatToIntBits(fov) : 0);
+		result = 31 * result + rdflags;
+		result = 31 * result + Arrays.hashCode(stats);
+		return result;
+	}
 
-		Com.Println("fov: " + fov);
-
-		Com.Println("rdflags: " + rdflags);
-
-		for (int n= 0; n < Defines.MAX_STATS; n++)
-			System.out.println("stats[" + n + "]: " + stats[n]);
+	@Override
+	public String toString() {
+		return "player_state_t{" +
+				"pmove=" + pmove +
+				", viewangles=" + Arrays.toString(viewangles) +
+				", viewoffset=" + Arrays.toString(viewoffset) +
+				", kick_angles=" + Arrays.toString(kick_angles) +
+				", gunangles=" + Arrays.toString(gunangles) +
+				", gunoffset=" + Arrays.toString(gunoffset) +
+				", gunindex=" + gunindex +
+				", gunframe=" + gunframe +
+				", blend=" + Arrays.toString(blend) +
+				", fov=" + fov +
+				", rdflags=" + rdflags +
+				", stats=" + Arrays.toString(stats) +
+				'}';
 	}
 }

--- a/qcommon/src/main/java/jake2/qcommon/pmove_state_t.java
+++ b/qcommon/src/main/java/jake2/qcommon/pmove_state_t.java
@@ -26,6 +26,7 @@ import jake2.qcommon.util.Math3D;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.util.Arrays;
 
 public class pmove_state_t {
 	//	this structure needs to be communicated bit-accurate
@@ -133,23 +134,44 @@ public class pmove_state_t {
 		f.writeShort(delta_angles[2]);
 	}
 
-	public void dump() {
-		Com.Println("pm_type: " + pm_type);
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
 
-		Com.Println("origin[0]: " + origin[0]);
-		Com.Println("origin[1]: " + origin[1]);
-		Com.Println("origin[2]: " + origin[2]);
+		pmove_state_t that = (pmove_state_t) o;
 
-		Com.Println("velocity[0]: " + velocity[0]);
-		Com.Println("velocity[1]: " + velocity[1]);
-		Com.Println("velocity[2]: " + velocity[2]);
+		if (pm_type != that.pm_type) return false;
+		if (pm_flags != that.pm_flags) return false;
+		if (pm_time != that.pm_time) return false;
+		if (gravity != that.gravity) return false;
+		if (!Arrays.equals(origin, that.origin)) return false;
+		if (!Arrays.equals(velocity, that.velocity)) return false;
+		return Arrays.equals(delta_angles, that.delta_angles);
+	}
 
-		Com.Println("pmflags: " + pm_flags);
-		Com.Println("pmtime: " + pm_time);
-		Com.Println("gravity: " + gravity);
+	@Override
+	public int hashCode() {
+		int result = pm_type;
+		result = 31 * result + Arrays.hashCode(origin);
+		result = 31 * result + Arrays.hashCode(velocity);
+		result = 31 * result + (int) pm_flags;
+		result = 31 * result + (int) pm_time;
+		result = 31 * result + (int) gravity;
+		result = 31 * result + Arrays.hashCode(delta_angles);
+		return result;
+	}
 
-		Com.Println("delta-angle[0]: " + delta_angles[0]);
-		Com.Println("delta-angle[1]: " + delta_angles[1]);
-		Com.Println("delta-angle[2]: " + delta_angles[2]);
+	@Override
+	public String toString() {
+		return "pmove_state_t{" +
+				"pm_type=" + pm_type +
+				", origin=" + Arrays.toString(origin) +
+				", velocity=" + Arrays.toString(velocity) +
+				", pm_flags=" + pm_flags +
+				", pm_time=" + pm_time +
+				", gravity=" + gravity +
+				", delta_angles=" + Arrays.toString(delta_angles) +
+				'}';
 	}
 }

--- a/qcommon/src/test/java/jake2/qcommon/network/messages/server/ServerMessageSizeTest.java
+++ b/qcommon/src/test/java/jake2/qcommon/network/messages/server/ServerMessageSizeTest.java
@@ -13,7 +13,12 @@ import static jake2.qcommon.Defines.*;
 import static org.junit.Assert.assertEquals;
 
 /**
- * This test checks that size estimation for each server message class is correct.
+ * This test checks that
+ * <ol>
+ * <li>size estimation for each server message class is correct</li>
+ * <li>size of the message is equal to the bytes in the buffer</li>
+ * <li>the message is the same during serialization/deserialization</li>
+ * </ol>
  * Validated by writing the message to the buffer and comparing the size.
  */
 @RunWith(Parameterized.class)
@@ -104,7 +109,10 @@ public class ServerMessageSizeTest {
                 }})},
                 {new PacketEntitiesMessage() {{
                     updates.add(new EntityUpdate(new DeltaEntityHeader(U_REMOVE, 32)));
-                    //updates.add(new EntityUpdate(new entity_state_t(new edict_t(1)), new entity_state_t(new edict_t(1)), false, true));
+                    updates.add(new EntityUpdate(new entity_state_t(new edict_t(1)), new entity_state_t(new edict_t(1)) {{
+                        modelindex = 3;
+                        origin = new float[]{2, 3, 4};
+                    }}, false, true));
                 }}}
         });
     }

--- a/qcommon/src/test/java/jake2/qcommon/network/messages/server/ServerMessageSizeTest.java
+++ b/qcommon/src/test/java/jake2/qcommon/network/messages/server/ServerMessageSizeTest.java
@@ -1,0 +1,84 @@
+package jake2.qcommon.network.messages.server;
+
+import jake2.qcommon.SZ;
+import jake2.qcommon.sizebuf_t;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.awt.*;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static jake2.qcommon.Defines.MAX_ITEMS;
+import static org.junit.Assert.*;
+
+/**
+ * This test checks that size estimation for each server message class is correct.
+ * Validated by writing the message to the buffer and comparing the size.
+ */
+@RunWith(Parameterized.class)
+public class ServerMessageSizeTest {
+    private static final int SIZE = 1024;
+    sizebuf_t buffer = new sizebuf_t();
+    byte[] data = new byte[SIZE];
+
+    ServerMessage message;
+
+    public ServerMessageSizeTest(ServerMessage message) {
+        this.message = message;
+    }
+
+    @Parameterized.Parameters(name = "{index}, {0}")
+    public static Collection<Object[]> primeNumbers() {
+        return Arrays.asList(new Object[][]{
+                {new DownloadMessage(new byte[]{1, 2, 3}, 50)},
+                {new DownloadMessage()},
+                {new DisconnectMessage()},
+                {new NopMessage()},
+                {new EndOfServerPacketMessage()},
+                {new LayoutMessage("layout")},
+                {new ConfigStringMessage(4, "config")},
+                {new ServerDataMessage(4, 3, false, "hello quake", 1, "q3dm6")},
+                {new StuffTextMessage("stuff")},
+                {new FrameHeaderMessage(1, 2, 3, 4, new byte[]{1, 1, 1, 1})},
+                {new InventoryMessage(new int[MAX_ITEMS])},
+                {new MuzzleFlash2Message(1, 2)},
+                {new PrintCenterMessage("hello")},
+                {new PrintMessage(3, "hello")},
+                {new WeaponSoundMessage(1, 2)},
+                {new BeamTEMessage(1, 2, new float[3], new float[3])},
+                {new PointTEMessage(4, new float[3])},
+                {new SplashTEMessage(4, 5, new float[3], new float[3], 6)},
+                {new BeamOffsetTEMessage(5, 8, new float[3], new float[3], new float[3])},
+                {new PointDirectionTEMessage(4, new float[3], new float[3])},
+                {new TrailTEMessage(4, new float[3], new float[3])}
+        });
+    }
+
+    @Test
+    public void testMessageSize() {
+        SZ.Init(buffer, data, SIZE);
+        message.writeTo(buffer);
+        assertEquals(buffer.cursize, message.getSize());
+    }
+
+    //
+//    @Test
+//    public void frameHeaderMesssageSize() {
+//        var msg = ;
+//        checkMessageSize(new InventoryMessage(new int[MAX_ITEMS]));
+//    }
+//
+//    @Test
+//    public void inventoryMesssageSize() {
+//        checkMessageSize();
+//    }
+//
+    private void checkMessageSize(ServerMessage msg) {
+        msg.writeTo(buffer);
+        assertEquals(buffer.cursize, msg.getSize());
+    }
+
+}

--- a/qcommon/src/test/java/jake2/qcommon/network/messages/server/ServerMessageSizeTest.java
+++ b/qcommon/src/test/java/jake2/qcommon/network/messages/server/ServerMessageSizeTest.java
@@ -1,18 +1,19 @@
 package jake2.qcommon.network.messages.server;
 
 import jake2.qcommon.SZ;
+import jake2.qcommon.edict_t;
+import jake2.qcommon.entity_state_t;
 import jake2.qcommon.sizebuf_t;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.awt.*;
 import java.util.Arrays;
 import java.util.Collection;
 
 import static jake2.qcommon.Defines.MAX_ITEMS;
-import static org.junit.Assert.*;
+import static jake2.qcommon.Defines.RF_BEAM;
+import static org.junit.Assert.assertEquals;
 
 /**
  * This test checks that size estimation for each server message class is correct.
@@ -53,7 +54,25 @@ public class ServerMessageSizeTest {
                 {new SplashTEMessage(4, 5, new float[3], new float[3], 6)},
                 {new BeamOffsetTEMessage(5, 8, new float[3], new float[3], new float[3])},
                 {new PointDirectionTEMessage(4, new float[3], new float[3])},
-                {new TrailTEMessage(4, new float[3], new float[3])}
+                {new TrailTEMessage(4, new float[3], new float[3])},
+                {new SpawnBaselineMessage(new entity_state_t(new edict_t(1)))},
+                {new SpawnBaselineMessage(new entity_state_t(new edict_t(1)) {{
+                    origin = new float[]{1, 2, 3};
+                    number = 1000;
+                    angles = new float[]{4, 5, 6};
+                    skinnum = 2222;
+                    frame = 3333;
+                    effects = 4444;
+                    renderfx = RF_BEAM;
+                    solid = 4;
+                    event = 5;
+                    modelindex = 123;
+                    modelindex2 = 234;
+                    modelindex3 = 345;
+                    modelindex4 = 456;
+                    sound = 32;
+                    old_origin = new float[]{2, 3, 4};
+                }})}
         });
     }
 
@@ -63,22 +82,4 @@ public class ServerMessageSizeTest {
         message.writeTo(buffer);
         assertEquals(buffer.cursize, message.getSize());
     }
-
-    //
-//    @Test
-//    public void frameHeaderMesssageSize() {
-//        var msg = ;
-//        checkMessageSize(new InventoryMessage(new int[MAX_ITEMS]));
-//    }
-//
-//    @Test
-//    public void inventoryMesssageSize() {
-//        checkMessageSize();
-//    }
-//
-    private void checkMessageSize(ServerMessage msg) {
-        msg.writeTo(buffer);
-        assertEquals(buffer.cursize, msg.getSize());
-    }
-
 }

--- a/qcommon/src/test/java/jake2/qcommon/network/messages/server/ServerMessageSizeTest.java
+++ b/qcommon/src/test/java/jake2/qcommon/network/messages/server/ServerMessageSizeTest.java
@@ -101,7 +101,11 @@ public class ServerMessageSizeTest {
                     gunangles = new float[]{3, 2, 1};
                     gunoffset = new float[]{6, 4, 2};
                     stats = new short[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1};
-                }})}
+                }})},
+                {new PacketEntitiesMessage() {{
+                    updates.add(new EntityUpdate(new DeltaEntityHeader(U_REMOVE, 32)));
+                    //updates.add(new EntityUpdate(new entity_state_t(new edict_t(1)), new entity_state_t(new edict_t(1)), false, true));
+                }}}
         });
     }
 

--- a/qcommon/src/test/java/jake2/qcommon/network/messages/server/ServerMessageSizeTest.java
+++ b/qcommon/src/test/java/jake2/qcommon/network/messages/server/ServerMessageSizeTest.java
@@ -8,8 +8,7 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static jake2.qcommon.Defines.MAX_ITEMS;
-import static jake2.qcommon.Defines.RF_BEAM;
+import static jake2.qcommon.Defines.*;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -29,8 +28,9 @@ public class ServerMessageSizeTest {
     }
 
     @Parameterized.Parameters(name = "{index}, {0}")
-    public static Collection<Object[]> primeNumbers() {
+    public static Collection<Object[]> createTestData() {
         return Arrays.asList(new Object[][]{
+                // ordinary messages
                 {new DownloadMessage(new byte[]{1, 2, 3}, 50)},
                 {new DownloadMessage()},
                 {new DisconnectMessage()},
@@ -47,12 +47,14 @@ public class ServerMessageSizeTest {
                 {new PrintCenterMessage("hello")},
                 {new PrintMessage(3, "hello")},
                 {new WeaponSoundMessage(1, 2)},
-                {new BeamTEMessage(1, 2, new float[3], new float[3])},
-                {new PointTEMessage(4, new float[3])},
-                {new SplashTEMessage(4, 5, new float[3], new float[3], 6)},
-                {new BeamOffsetTEMessage(5, 8, new float[3], new float[3], new float[3])},
-                {new PointDirectionTEMessage(4, new float[3], new float[3])},
-                {new TrailTEMessage(4, new float[3], new float[3])},
+                // Temp entities
+                {new PointTEMessage(TE_BOSSTPORT, new float[3])},
+                {new BeamTEMessage(TE_PARASITE_ATTACK, 2, new float[3], new float[3])},
+                {new SplashTEMessage(TE_LASER_SPARKS, 5, new float[3], new float[3], 6)},
+                {new BeamOffsetTEMessage(TE_GRAPPLE_CABLE, 8, new float[3], new float[3], new float[3])},
+                {new PointDirectionTEMessage(TE_GUNSHOT, new float[3], new float[3])},
+                {new TrailTEMessage(TE_BUBBLETRAIL, new float[3], new float[3])},
+                // delta compressed
                 {new SpawnBaselineMessage(new entity_state_t(new edict_t(1)))},
                 {new SpawnBaselineMessage(new entity_state_t(new edict_t(1)) {{
                     origin = new float[]{1, 2, 3};
@@ -100,6 +102,10 @@ public class ServerMessageSizeTest {
     public void testMessageSize() {
         SZ.Init(buffer, data, SIZE);
         message.writeTo(buffer);
-        assertEquals(buffer.cursize, message.getSize());
+        assertEquals("Message size != buffer size", buffer.cursize, message.getSize());
+
+        ServerMessage parsed = ServerMessage.parseFromBuffer(buffer);
+        assertEquals("Buffer is not read fully", buffer.cursize, buffer.readcount);
+        //assertEquals(parsed, message);
     }
 }

--- a/qcommon/src/test/java/jake2/qcommon/network/messages/server/ServerMessageSizeTest.java
+++ b/qcommon/src/test/java/jake2/qcommon/network/messages/server/ServerMessageSizeTest.java
@@ -1,9 +1,6 @@
 package jake2.qcommon.network.messages.server;
 
-import jake2.qcommon.SZ;
-import jake2.qcommon.edict_t;
-import jake2.qcommon.entity_state_t;
-import jake2.qcommon.sizebuf_t;
+import jake2.qcommon.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -37,6 +34,7 @@ public class ServerMessageSizeTest {
                 {new DownloadMessage(new byte[]{1, 2, 3}, 50)},
                 {new DownloadMessage()},
                 {new DisconnectMessage()},
+                {new ReconnectMessage()},
                 {new NopMessage()},
                 {new EndOfServerPacketMessage()},
                 {new LayoutMessage("layout")},
@@ -72,6 +70,28 @@ public class ServerMessageSizeTest {
                     modelindex4 = 456;
                     sound = 32;
                     old_origin = new float[]{2, 3, 4};
+                }})},
+                {new PlayerInfoMessage(new player_state_t(), new player_state_t() {{
+                    pmove = new pmove_state_t() {{
+                        origin = new short[]{0, 1, 2};
+                        velocity = new short[]{1, 1, 1};
+                        pm_type = 2;
+                        pm_time = 50;
+                        pm_flags = 1;
+                        gravity = 600;
+                        delta_angles = new short[]{3, 4, 5};
+                    }};
+                    kick_angles = new float[]{2, 2, 2};
+                    viewoffset = new float[]{1, 3, 5};
+                    viewangles = new float[]{2, 4, 6};
+                    blend = new float[]{1, 2, 3, 4};
+                    fov = 70;
+                    rdflags = 2;
+                    gunindex = 23;
+                    gunframe = 12;
+                    gunangles = new float[]{3, 2, 1};
+                    gunoffset = new float[]{6, 4, 2};
+                    stats = new short[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1};
                 }})}
         });
     }

--- a/qcommon/src/test/java/jake2/qcommon/network/messages/server/ServerMessageSizeTest.java
+++ b/qcommon/src/test/java/jake2/qcommon/network/messages/server/ServerMessageSizeTest.java
@@ -9,7 +9,7 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static jake2.qcommon.Defines.RF_BEAM;
+import static jake2.qcommon.Defines.*;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -31,7 +31,6 @@ public class ServerMessageSizeTest {
     @Parameterized.Parameters(name = "{index}, {0}")
     public static Collection<Object[]> createTestData() {
         return Arrays.asList(new Object[][]{
-/*
                 // null/empty markers
                 {new NopMessage()},
                 {new EndOfServerPacketMessage()},
@@ -60,9 +59,9 @@ public class ServerMessageSizeTest {
                 // this direction is taken from: jake2.qcommon.Globals.bytedirs
                 {new PointDirectionTEMessage(TE_GUNSHOT, new float[3], new float[]{-0.525731f, 0.000000f, 0.850651f})},
                 {new TrailTEMessage(TE_BUBBLETRAIL, new float[3], new float[3])},
+                {new SoundMessage(SND_VOLUME | SND_ATTENUATION | SND_OFFSET | SND_ENT | SND_POS, 2, 1, 2, 0.2f, 1, new float[]{1, 2, 3})},
                 // delta compressed
                 {new SpawnBaselineMessage(new entity_state_t(new edict_t(1)))},
-*/
                 {new SpawnBaselineMessage(new entity_state_t(new edict_t(1)) {{
                     origin = new float[]{1, 2, 3};
                     number = 1000;
@@ -93,8 +92,8 @@ public class ServerMessageSizeTest {
                     }};
                     kick_angles = new float[]{2, 2, 2};
                     viewoffset = new float[]{1, 3, 5};
-                    viewangles = new float[]{2, 4, 6};
-                    blend = new float[]{1, 2, 3, 4};
+                    viewangles = new float[]{1.9995117f, 3.9990234f, 5.998535f};
+                    blend = new float[]{0.09803922f, 0.2f, 0.29803923f, 0.4f};
                     fov = 70;
                     rdflags = 2;
                     gunindex = 23;

--- a/server/src/main/java/jake2/server/GameImportsImpl.java
+++ b/server/src/main/java/jake2/server/GameImportsImpl.java
@@ -78,8 +78,6 @@ public class GameImportsImpl implements GameImports {
     client_t sv_client; // current client
 
     final float[] origin_v = { 0, 0, 0 };
-    final sizebuf_t msg = new sizebuf_t();
-    final byte[] msgbuf = new byte[Defines.MAX_MSGLEN];
 
     public GameImportsImpl(JakeServer serverMain) {
         this.serverMain = serverMain;

--- a/server/src/main/java/jake2/server/SV_ENTS.java
+++ b/server/src/main/java/jake2/server/SV_ENTS.java
@@ -71,94 +71,31 @@ public class SV_ENTS {
     static PlayerInfoMessage buildPlayerInfoMessage(player_state_t lastFrameState, player_state_t currentPlayerState) {
         player_state_t ops = lastFrameState != null ? lastFrameState : new player_state_t();
 
-        // determine what needs to be sent
-        int messageFlags = 0;
 
-        if (currentPlayerState.pmove.pm_type != ops.pmove.pm_type)
-            messageFlags |= Defines.PS_M_TYPE;
+        return new PlayerInfoMessage(ops, currentPlayerState);
 
-        if (currentPlayerState.pmove.origin[0] != ops.pmove.origin[0]
-                || currentPlayerState.pmove.origin[1] != ops.pmove.origin[1]
-                || currentPlayerState.pmove.origin[2] != ops.pmove.origin[2])
-            messageFlags |= Defines.PS_M_ORIGIN;
-
-        if (currentPlayerState.pmove.velocity[0] != ops.pmove.velocity[0]
-                || currentPlayerState.pmove.velocity[1] != ops.pmove.velocity[1]
-                || currentPlayerState.pmove.velocity[2] != ops.pmove.velocity[2])
-            messageFlags |= Defines.PS_M_VELOCITY;
-
-        if (currentPlayerState.pmove.pm_time != ops.pmove.pm_time)
-            messageFlags |= Defines.PS_M_TIME;
-
-        if (currentPlayerState.pmove.pm_flags != ops.pmove.pm_flags)
-            messageFlags |= Defines.PS_M_FLAGS;
-
-        if (currentPlayerState.pmove.gravity != ops.pmove.gravity)
-            messageFlags |= Defines.PS_M_GRAVITY;
-
-        if (currentPlayerState.pmove.delta_angles[0] != ops.pmove.delta_angles[0]
-                || currentPlayerState.pmove.delta_angles[1] != ops.pmove.delta_angles[1]
-                || currentPlayerState.pmove.delta_angles[2] != ops.pmove.delta_angles[2])
-            messageFlags |= Defines.PS_M_DELTA_ANGLES;
-
-        if (currentPlayerState.viewoffset[0] != ops.viewoffset[0]
-                || currentPlayerState.viewoffset[1] != ops.viewoffset[1]
-                || currentPlayerState.viewoffset[2] != ops.viewoffset[2])
-            messageFlags |= Defines.PS_VIEWOFFSET;
-
-        if (currentPlayerState.viewangles[0] != ops.viewangles[0]
-                || currentPlayerState.viewangles[1] != ops.viewangles[1]
-                || currentPlayerState.viewangles[2] != ops.viewangles[2])
-            messageFlags |= Defines.PS_VIEWANGLES;
-
-        if (currentPlayerState.kick_angles[0] != ops.kick_angles[0]
-                || currentPlayerState.kick_angles[1] != ops.kick_angles[1]
-                || currentPlayerState.kick_angles[2] != ops.kick_angles[2])
-            messageFlags |= Defines.PS_KICKANGLES;
-
-        if (currentPlayerState.blend[0] != ops.blend[0] || currentPlayerState.blend[1] != ops.blend[1]
-                || currentPlayerState.blend[2] != ops.blend[2] || currentPlayerState.blend[3] != ops.blend[3])
-            messageFlags |= Defines.PS_BLEND;
-
-        if (currentPlayerState.fov != ops.fov)
-            messageFlags |= Defines.PS_FOV;
-
-        messageFlags |= Defines.PS_WEAPONINDEX;
-
-        if (currentPlayerState.gunframe != ops.gunframe)
-            messageFlags |= Defines.PS_WEAPONFRAME;
-
-        if (currentPlayerState.rdflags != ops.rdflags)
-            messageFlags |= Defines.PS_RDFLAGS;
-
-        // send stats
-        int statbits = 0;
-        for (int i = 0; i < Defines.MAX_STATS; i++)
-            if (currentPlayerState.stats[i] != ops.stats[i])
-                statbits |= 1 << i;
-
-        return new PlayerInfoMessage(
-                messageFlags,
-                currentPlayerState.pmove.pm_type,
-                currentPlayerState.pmove.origin,
-                currentPlayerState.pmove.velocity,
-                currentPlayerState.pmove.pm_time,
-                currentPlayerState.pmove.pm_flags,
-                currentPlayerState.pmove.gravity,
-                currentPlayerState.pmove.delta_angles,
-                currentPlayerState.viewoffset,
-                currentPlayerState.viewangles,
-                currentPlayerState.kick_angles,
-                currentPlayerState.gunindex,
-                currentPlayerState.gunframe,
-                currentPlayerState.gunoffset,
-                currentPlayerState.gunangles,
-                currentPlayerState.blend,
-                currentPlayerState.fov,
-                currentPlayerState.rdflags,
-                statbits,
-                currentPlayerState.stats
-        );
+//        return new PlayerInfoMessage(
+//                messageFlags,
+//                currentState.pmove.pm_type,
+//                currentState.pmove.origin,
+//                currentState.pmove.velocity,
+//                currentState.pmove.pm_time,
+//                currentState.pmove.pm_flags,
+//                currentState.pmove.gravity,
+//                currentState.pmove.delta_angles,
+//                currentState.viewoffset,
+//                currentState.viewangles,
+//                currentState.kick_angles,
+//                currentState.gunindex,
+//                currentState.gunframe,
+//                currentState.gunoffset,
+//                currentState.gunangles,
+//                currentState.blend,
+//                currentState.fov,
+//                currentState.rdflags,
+//                statbits,
+//                currentState.stats
+//        );
     }
 
     /**

--- a/server/src/main/java/jake2/server/SV_MAIN.java
+++ b/server/src/main/java/jake2/server/SV_MAIN.java
@@ -503,7 +503,6 @@ public class SV_MAIN implements JakeServer {
 
     void SV_SendClientMessages() {
 
-        int msglen = 0;
         server_t sv = gameImports.sv;
         // send a message to each connected client
         // todo send only to related clients
@@ -521,9 +520,10 @@ public class SV_MAIN implements JakeServer {
                 SV_DropClient(c);
             }
 
-            if (sv.state == ServerStates.SS_CINEMATIC || sv.state == ServerStates.SS_DEMO || sv.state == ServerStates.SS_PIC)
-                Netchan.Transmit(c.netchan, msglen, gameImports.msgbuf);
-            else if (c.state == ClientStates.CS_SPAWNED) {
+            if (sv.state == ServerStates.SS_CINEMATIC || sv.state == ServerStates.SS_DEMO || sv.state == ServerStates.SS_PIC) {
+                // leftover from demo code
+                Netchan.Transmit(c.netchan, 0, NULLBYTE);
+            } else if (c.state == ClientStates.CS_SPAWNED) {
                 // don't overrun bandwidth
                 if (SV_RateDrop(c))
                     continue;

--- a/server/src/main/java/jake2/server/SV_MAIN.java
+++ b/server/src/main/java/jake2/server/SV_MAIN.java
@@ -679,7 +679,7 @@ public class SV_MAIN implements JakeServer {
         int stringCmdCount = 0;
 
         for (ClientMessage msg : clientMessages) {
-            if (msg instanceof EndMessage) {
+            if (msg instanceof EndOfClientPacketMessage) {
                 break;
             } else if (msg instanceof StringCmdMessage) {
                 StringCmdMessage m = (StringCmdMessage) msg;


### PR DESCRIPTION
To move away from using byte arrays in the networking layer, a size (in bytes) is required for the server messages, in order to estimate the bandwidth usage.
In this PR:
  * size() function is implemented for all server messages, returning the size of the payload in bytes
  * test added to validate that size estimation is exactly the same as the bytes written to the buffer in the old behavior
  * improved TempEntitiy messaging api - added validation of the style value
  * improved PlayerInfoMessage api - now requires only player_state value (old/new) to be instantiated.
  * add tests for message size and serialization/deserialization code