### PR TITLE
Network messages (both reliable & non reliable) are staged in a collection instead of the byte buffers.

### DIFF
--- a/client/src/main/java/jake2/client/CL.java
+++ b/client/src/main/java/jake2/client/CL.java
@@ -277,7 +277,7 @@ public final class CL {
 
         // don't forward the first argument
         if (args.size() > 1) {
-            new StringCmdMessage(getArguments(args)).writeTo(ClientGlobals.cls.netchan.reliable);
+            ClientGlobals.cls.netchan.reliable.add(new StringCmdMessage(getArguments(args)));
         }
     };
 
@@ -413,7 +413,7 @@ public final class CL {
         if (ClientGlobals.cls.state == Defines.ca_connected) {
             Com.Printf("reconnecting...\n");
             ClientGlobals.cls.state = Defines.ca_connected;
-            new StringCmdMessage(StringCmdMessage.NEW).writeTo(ClientGlobals.cls.netchan.reliable);
+            ClientGlobals.cls.netchan.reliable.add(new StringCmdMessage(StringCmdMessage.NEW));
             return;
         }
 
@@ -538,7 +538,7 @@ public final class CL {
         ClientGlobals.cls.downloadtempname = Com
                 .StripExtension(ClientGlobals.cls.downloadname);
         ClientGlobals.cls.downloadtempname += ".tmp";
-        new StringCmdMessage(StringCmdMessage.DOWNLOAD + " " + ClientGlobals.cls.downloadname).writeTo(ClientGlobals.cls.netchan.reliable);
+        ClientGlobals.cls.netchan.reliable.add(new StringCmdMessage(StringCmdMessage.DOWNLOAD + " " + ClientGlobals.cls.downloadname));
         ClientGlobals.cls.downloadnumber++;
     };
 
@@ -745,7 +745,7 @@ public final class CL {
                     break;
                 }
                 Netchan.Setup(Defines.NS_CLIENT, ClientGlobals.cls.netchan, packet.from, ClientGlobals.cls.quakePort);
-                new StringCmdMessage(StringCmdMessage.NEW).writeTo(ClientGlobals.cls.netchan.reliable);
+                ClientGlobals.cls.netchan.reliable.add(new StringCmdMessage(StringCmdMessage.NEW));
                 ClientGlobals.cls.state = Defines.ca_connected;
                 break;
 
@@ -1170,7 +1170,7 @@ public final class CL {
         CL_parse.RegisterSounds();
         CL_view.PrepRefresh();
 
-        new StringCmdMessage(StringCmdMessage.BEGIN + " " + CL.precache_spawncount + "\n").writeTo(ClientGlobals.cls.netchan.reliable);
+        ClientGlobals.cls.netchan.reliable.add(new StringCmdMessage(StringCmdMessage.BEGIN + " " + CL.precache_spawncount + "\n"));
     }
 
     /**

--- a/client/src/main/java/jake2/client/CL.java
+++ b/client/src/main/java/jake2/client/CL.java
@@ -698,7 +698,7 @@ public final class CL {
         new StringCmdMessage(StringCmdMessage.DISCONNECT).writeTo(buf);
 
         // fixme: was sending it 3 times
-        Netchan.Transmit(ClientGlobals.cls.netchan, buf.cursize, buf.data);
+        Netchan.Transmit(ClientGlobals.cls.netchan, List.of(new StringCmdMessage(StringCmdMessage.DISCONNECT)));
 
 
         ClearState();

--- a/client/src/main/java/jake2/client/CL.java
+++ b/client/src/main/java/jake2/client/CL.java
@@ -560,6 +560,7 @@ public final class CL {
      * 
      * Dumps the current net message, prefixed by the length
      */
+    /*
     static void WriteDemoMessage() {
         int swlen;
 
@@ -573,7 +574,7 @@ public final class CL {
         }
 
     }
-
+    */
     /**
      * SendConnectPacket
      * 
@@ -1577,9 +1578,6 @@ public final class CL {
         V.Init();
         Cmd.AddCommand("cl_drop", args -> CL.Drop());
         Cmd.AddCommand("cl_shutdown", args -> CL.Shutdown());
-
-        Globals.net_message.data = Globals.net_message_buffer;
-        Globals.net_message.maxsize = Globals.net_message_buffer.length;
 
         Menu.Init();
 

--- a/client/src/main/java/jake2/client/CL.java
+++ b/client/src/main/java/jake2/client/CL.java
@@ -277,7 +277,7 @@ public final class CL {
 
         // don't forward the first argument
         if (args.size() > 1) {
-            new StringCmdMessage(getArguments(args)).writeTo(ClientGlobals.cls.netchan.message);
+            new StringCmdMessage(getArguments(args)).writeTo(ClientGlobals.cls.netchan.reliable);
         }
     };
 
@@ -413,7 +413,7 @@ public final class CL {
         if (ClientGlobals.cls.state == Defines.ca_connected) {
             Com.Printf("reconnecting...\n");
             ClientGlobals.cls.state = Defines.ca_connected;
-            new StringCmdMessage(StringCmdMessage.NEW).writeTo(ClientGlobals.cls.netchan.message);
+            new StringCmdMessage(StringCmdMessage.NEW).writeTo(ClientGlobals.cls.netchan.reliable);
             return;
         }
 
@@ -538,7 +538,7 @@ public final class CL {
         ClientGlobals.cls.downloadtempname = Com
                 .StripExtension(ClientGlobals.cls.downloadname);
         ClientGlobals.cls.downloadtempname += ".tmp";
-        new StringCmdMessage(StringCmdMessage.DOWNLOAD + " " + ClientGlobals.cls.downloadname).writeTo(ClientGlobals.cls.netchan.message);
+        new StringCmdMessage(StringCmdMessage.DOWNLOAD + " " + ClientGlobals.cls.downloadname).writeTo(ClientGlobals.cls.netchan.reliable);
         ClientGlobals.cls.downloadnumber++;
     };
 
@@ -651,7 +651,7 @@ public final class CL {
             ClientGlobals.cl_entities[i] = new centity_t();
         }
 
-        ClientGlobals.cls.netchan.message.clear();
+        ClientGlobals.cls.netchan.reliable.clear();
     }
 
     /**
@@ -745,7 +745,7 @@ public final class CL {
                     break;
                 }
                 Netchan.Setup(Defines.NS_CLIENT, ClientGlobals.cls.netchan, packet.from, ClientGlobals.cls.quakePort);
-                new StringCmdMessage(StringCmdMessage.NEW).writeTo(ClientGlobals.cls.netchan.message);
+                new StringCmdMessage(StringCmdMessage.NEW).writeTo(ClientGlobals.cls.netchan.reliable);
                 ClientGlobals.cls.state = Defines.ca_connected;
                 break;
 
@@ -1170,7 +1170,7 @@ public final class CL {
         CL_parse.RegisterSounds();
         CL_view.PrepRefresh();
 
-        new StringCmdMessage(StringCmdMessage.BEGIN + " " + CL.precache_spawncount + "\n").writeTo(ClientGlobals.cls.netchan.message);
+        new StringCmdMessage(StringCmdMessage.BEGIN + " " + CL.precache_spawncount + "\n").writeTo(ClientGlobals.cls.netchan.reliable);
     }
 
     /**

--- a/client/src/main/java/jake2/client/CL_input.java
+++ b/client/src/main/java/jake2/client/CL_input.java
@@ -420,7 +420,7 @@ public class CL_input {
 			return;
 
 		if (ClientGlobals.cls.state == Defines.ca_connected) {
-			if (ClientGlobals.cls.netchan.message.cursize != 0 || Globals.curtime - ClientGlobals.cls.netchan.last_sent > 1000)
+			if (ClientGlobals.cls.netchan.reliable.cursize != 0 || Globals.curtime - ClientGlobals.cls.netchan.last_sent > 1000)
 				Netchan.Transmit(ClientGlobals.cls.netchan, 0, new byte[0]);
 			return;
 		}
@@ -429,7 +429,7 @@ public class CL_input {
 		if (Globals.userinfo_modified) {
 			CL.FixUpGender();
 			Globals.userinfo_modified = false;
-			new UserInfoMessage(Cvar.getInstance().Userinfo()).writeTo(ClientGlobals.cls.netchan.message);
+			new UserInfoMessage(Cvar.getInstance().Userinfo()).writeTo(ClientGlobals.cls.netchan.reliable);
 		}
 
 

--- a/client/src/main/java/jake2/client/CL_input.java
+++ b/client/src/main/java/jake2/client/CL_input.java
@@ -420,7 +420,7 @@ public class CL_input {
 			return;
 
 		if (ClientGlobals.cls.state == Defines.ca_connected) {
-			if (ClientGlobals.cls.netchan.reliable.cursize != 0 || Globals.curtime - ClientGlobals.cls.netchan.last_sent > 1000)
+			if (ClientGlobals.cls.netchan.reliable.size() != 0 || Globals.curtime - ClientGlobals.cls.netchan.last_sent > 1000)
 				Netchan.Transmit(ClientGlobals.cls.netchan, null);
 			return;
 		}
@@ -429,7 +429,7 @@ public class CL_input {
 		if (Globals.userinfo_modified) {
 			CL.FixUpGender();
 			Globals.userinfo_modified = false;
-			new UserInfoMessage(Cvar.getInstance().Userinfo()).writeTo(ClientGlobals.cls.netchan.reliable);
+			ClientGlobals.cls.netchan.reliable.add(new UserInfoMessage(Cvar.getInstance().Userinfo()));
 		}
 
 

--- a/client/src/main/java/jake2/client/CL_input.java
+++ b/client/src/main/java/jake2/client/CL_input.java
@@ -421,7 +421,7 @@ public class CL_input {
 
 		if (ClientGlobals.cls.state == Defines.ca_connected) {
 			if (ClientGlobals.cls.netchan.reliable.cursize != 0 || Globals.curtime - ClientGlobals.cls.netchan.last_sent > 1000)
-				Netchan.Transmit(ClientGlobals.cls.netchan, 0, new byte[0]);
+				Netchan.Transmit(ClientGlobals.cls.netchan, null);
 			return;
 		}
 
@@ -454,21 +454,16 @@ public class CL_input {
 		int latestCmdIndex = ClientGlobals.cls.netchan.outgoing_sequence & (Defines.CMD_BACKUP - 1);
 		usercmd_t latestCmd = ClientGlobals.cl.cmds[latestCmdIndex];
 
-		// write MoveMessage to its own buffer
-		buf.init(data, data.length);
-
-		new MoveMessage(
+		//
+		// deliver the message
+		//
+		Netchan.Transmit(ClientGlobals.cls.netchan, List.of(new MoveMessage(
 				noCompress,
 				ClientGlobals.cl.frame.serverframe,
 				oldestCmd,
 				oldCmd,
 				latestCmd,
 				ClientGlobals.cls.netchan.outgoing_sequence
-		).writeTo(buf);
-
-		//
-		// deliver the message
-		//
-		Netchan.Transmit(ClientGlobals.cls.netchan, buf.cursize, buf.data);
+		)));
 	}
 }

--- a/client/src/main/java/jake2/client/CL_parse.java
+++ b/client/src/main/java/jake2/client/CL_parse.java
@@ -130,10 +130,10 @@ public class CL_parse {
 
             // give the server an offset to start the download
             Com.Printf("Resuming " + ClientGlobals.cls.downloadname + "\n");
-            new StringCmdMessage(StringCmdMessage.DOWNLOAD + " " + ClientGlobals.cls.downloadname + " " + len).writeTo(ClientGlobals.cls.netchan.reliable);
+            ClientGlobals.cls.netchan.reliable.add(new StringCmdMessage(StringCmdMessage.DOWNLOAD + " " + ClientGlobals.cls.downloadname + " " + len));
         } else {
             Com.Printf("Downloading " + ClientGlobals.cls.downloadname + "\n");
-            new StringCmdMessage(StringCmdMessage.DOWNLOAD + " " + ClientGlobals.cls.downloadname).writeTo(ClientGlobals.cls.netchan.reliable);
+            ClientGlobals.cls.netchan.reliable.add(new StringCmdMessage(StringCmdMessage.DOWNLOAD + " " + ClientGlobals.cls.downloadname));
         }
 
         ClientGlobals.cls.downloadnumber++;
@@ -211,7 +211,7 @@ public class CL_parse {
             // request next block
             //	   change display routines by zoid
             ClientGlobals.cls.downloadpercent = percent;
-            new StringCmdMessage(StringCmdMessage.NEXT_DOWNLOAD).writeTo(ClientGlobals.cls.netchan.reliable);
+            ClientGlobals.cls.netchan.reliable.add(new StringCmdMessage(StringCmdMessage.NEXT_DOWNLOAD));
         } else {
             try {
                 ClientGlobals.cls.download.close();

--- a/client/src/main/java/jake2/client/CL_parse.java
+++ b/client/src/main/java/jake2/client/CL_parse.java
@@ -25,7 +25,10 @@ package jake2.client;
 
 import jake2.client.render.model_t;
 import jake2.client.sound.S;
-import jake2.qcommon.*;
+import jake2.qcommon.Com;
+import jake2.qcommon.Defines;
+import jake2.qcommon.Globals;
+import jake2.qcommon.ServerStates;
 import jake2.qcommon.exec.Cbuf;
 import jake2.qcommon.exec.Cvar;
 import jake2.qcommon.filesystem.FS;
@@ -520,12 +523,6 @@ public class CL_parse {
                 soundMsg.attenuation,
                 soundMsg.timeOffset);
     }
-
-    public static void SHOWNET(String s) {
-        if (ClientGlobals.cl_shownet.value >= 2)
-            Com.Printf(Globals.net_message.readcount - 1 + ":" + s + "\n");
-    }
-
 
     static frame_t old;
 

--- a/client/src/main/java/jake2/client/CL_parse.java
+++ b/client/src/main/java/jake2/client/CL_parse.java
@@ -130,10 +130,10 @@ public class CL_parse {
 
             // give the server an offset to start the download
             Com.Printf("Resuming " + ClientGlobals.cls.downloadname + "\n");
-            new StringCmdMessage(StringCmdMessage.DOWNLOAD + " " + ClientGlobals.cls.downloadname + " " + len).writeTo(ClientGlobals.cls.netchan.message);
+            new StringCmdMessage(StringCmdMessage.DOWNLOAD + " " + ClientGlobals.cls.downloadname + " " + len).writeTo(ClientGlobals.cls.netchan.reliable);
         } else {
             Com.Printf("Downloading " + ClientGlobals.cls.downloadname + "\n");
-            new StringCmdMessage(StringCmdMessage.DOWNLOAD + " " + ClientGlobals.cls.downloadname).writeTo(ClientGlobals.cls.netchan.message);
+            new StringCmdMessage(StringCmdMessage.DOWNLOAD + " " + ClientGlobals.cls.downloadname).writeTo(ClientGlobals.cls.netchan.reliable);
         }
 
         ClientGlobals.cls.downloadnumber++;
@@ -211,7 +211,7 @@ public class CL_parse {
             // request next block
             //	   change display routines by zoid
             ClientGlobals.cls.downloadpercent = percent;
-            new StringCmdMessage(StringCmdMessage.NEXT_DOWNLOAD).writeTo(ClientGlobals.cls.netchan.message);
+            new StringCmdMessage(StringCmdMessage.NEXT_DOWNLOAD).writeTo(ClientGlobals.cls.netchan.reliable);
         } else {
             try {
                 ClientGlobals.cls.download.close();

--- a/client/src/main/java/jake2/client/SCR.java
+++ b/client/src/main/java/jake2/client/SCR.java
@@ -1478,7 +1478,7 @@ public final class SCR extends Globals {
      */
     static void nextServerCommand() {
         // tell the server to advance to the next map / cinematic
-        new StringCmdMessage(StringCmdMessage.NEXT_SERVER + " " + ClientGlobals.cl.servercount + '\n').writeTo(cls.netchan.message);
+        new StringCmdMessage(StringCmdMessage.NEXT_SERVER + " " + ClientGlobals.cl.servercount + '\n').writeTo(cls.netchan.reliable);
     }
 
     // ==========================================================================

--- a/client/src/main/java/jake2/client/SCR.java
+++ b/client/src/main/java/jake2/client/SCR.java
@@ -1478,7 +1478,7 @@ public final class SCR extends Globals {
      */
     static void nextServerCommand() {
         // tell the server to advance to the next map / cinematic
-        new StringCmdMessage(StringCmdMessage.NEXT_SERVER + " " + ClientGlobals.cl.servercount + '\n').writeTo(cls.netchan.reliable);
+        cls.netchan.reliable.add(new StringCmdMessage(StringCmdMessage.NEXT_SERVER + " " + ClientGlobals.cl.servercount + '\n'));
     }
 
     // ==========================================================================

--- a/dedicated/src/main/java/jake2/dedicated/Jake2Dedicated.java
+++ b/dedicated/src/main/java/jake2/dedicated/Jake2Dedicated.java
@@ -8,7 +8,6 @@ import jake2.qcommon.exec.Cmd;
 import jake2.qcommon.exec.Cvar;
 import jake2.qcommon.filesystem.FS;
 import jake2.qcommon.longjmpException;
-import jake2.qcommon.network.NET;
 import jake2.qcommon.network.Netchan;
 import jake2.qcommon.sys.Sys;
 import jake2.qcommon.sys.Timer;
@@ -18,7 +17,8 @@ import jake2.server.SV_MAIN;
 import java.util.Arrays;
 import java.util.List;
 
-import static jake2.qcommon.MainCommon.*;
+import static jake2.qcommon.MainCommon.adjustTime;
+import static jake2.qcommon.MainCommon.debugLogTraces;
 
 public class Jake2Dedicated {
 
@@ -69,7 +69,6 @@ public class Jake2Dedicated {
             Globals.showtrace= Cvar.getInstance().Get("showtrace", "0", 0);
             Cvar.getInstance().Get("version", "1.0.0", Defines.CVAR_SERVERINFO | Defines.CVAR_NOSET);
 
-            NET.Init();	//ok
             Netchan.Netchan_Init();	//ok
 
             serverMain = new SV_MAIN();	//ok

--- a/fullgame/src/main/java/jake2/fullgame/Jake2.java
+++ b/fullgame/src/main/java/jake2/fullgame/Jake2.java
@@ -36,7 +36,6 @@ import jake2.qcommon.exec.Cmd;
 import jake2.qcommon.exec.Cvar;
 import jake2.qcommon.filesystem.FS;
 import jake2.qcommon.longjmpException;
-import jake2.qcommon.network.NET;
 import jake2.qcommon.network.Netchan;
 import jake2.qcommon.sys.Sys;
 import jake2.qcommon.sys.Timer;
@@ -46,7 +45,8 @@ import jake2.server.SV_MAIN;
 import java.util.Arrays;
 import java.util.List;
 
-import static jake2.qcommon.MainCommon.*;
+import static jake2.qcommon.MainCommon.adjustTime;
+import static jake2.qcommon.MainCommon.debugLogTraces;
 
 /**
  * Jake2 is the main class of Quake2 for Java.
@@ -179,8 +179,6 @@ public final class Jake2 {
             String version = Globals.VERSION + " " + CPUSTRING + " " + BUILDSTRING;
             Cvar.getInstance().Get("version", version, Defines.CVAR_SERVERINFO | Defines.CVAR_NOSET);
 
-
-            NET.Init();	//ok
             Netchan.Netchan_Init();	//ok
 
             result = new SV_MAIN(); //SV_MAIN.SV_Init();	//ok

--- a/qcommon/src/main/java/jake2/qcommon/GameImports.java
+++ b/qcommon/src/main/java/jake2/qcommon/GameImports.java
@@ -69,12 +69,6 @@ public interface GameImports {
 
     void Pmove(pmove_t pmove);
 
-    /*
-             player movement code common with client prediction
-             network messaging
-            */
-    void multicast(float[] origin, MulticastTypes to);
-
     /* console variable interaction */
     cvar_t cvar(String var_name, String value, int flags);
 

--- a/qcommon/src/main/java/jake2/qcommon/Globals.java
+++ b/qcommon/src/main/java/jake2/qcommon/Globals.java
@@ -26,9 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 package jake2.qcommon;
 
 import jake2.qcommon.exec.cvar_t;
-import jake2.qcommon.network.netadr_t;
 
-import java.io.FileWriter;
 import java.io.RandomAccessFile;
 import java.util.Random;
 
@@ -68,20 +66,6 @@ public class Globals extends Defines {
 	public static cvar_t showtrace;
 	public static cvar_t timescale;
 
-
-	public static sizebuf_t net_message = new sizebuf_t();
-
-	/*
-	=============================================================================
-	
-							COMMAND BUFFER
-	
-	=============================================================================
-	*/
-
-	//=============================================================================
-
-	public static byte[] net_message_buffer = new byte[MAX_MSGLEN];
 
 	public static int time_before_game;
 	public static int time_after_game;

--- a/qcommon/src/main/java/jake2/qcommon/network/NET.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/NET.java
@@ -217,13 +217,6 @@ public final class NET {
         }
     }
 
-    /**
-     * Init
-     */
-    public static void Init() {
-        Globals.net_message.init(Globals.net_message_buffer, Globals.net_message_buffer.length);
-    }
-
     /*
      * Socket
      */

--- a/qcommon/src/main/java/jake2/qcommon/network/Netchan.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/Netchan.java
@@ -147,28 +147,6 @@ public final class Netchan {
         chan.message.allowoverflow = true;
     }
 
-    /**
-     * Netchan_CanReliable. Returns true if the last reliable message has acked.
-     */
-    public static boolean Netchan_CanReliable(netchan_t chan) {
-        if (chan.reliable_length != 0)
-            return false; // waiting for ack
-        return true;
-    }
-
-    
-    public static boolean Netchan_NeedReliable(netchan_t chan) {
-        // if the remote side dropped the last reliable message, resend it
-        boolean send_reliable = chan.incoming_acknowledged > chan.last_reliable_sequence
-                && chan.incoming_reliable_acknowledged != chan.reliable_sequence;
-
-        // if the reliable transmit buffer is empty, copy the current message out
-        if (0 == chan.reliable_length && chan.message.cursize != 0) {
-            send_reliable = true;
-        }
-
-        return send_reliable;
-    }
 
     /**
      * Netchan_Transmit tries to send an unreliable message to a connection, 
@@ -187,7 +165,7 @@ public final class Netchan {
             return;
         }
 
-        int send_reliable = Netchan_NeedReliable(chan) ? 1 : 0;
+        int send_reliable = chan.needReliable() ? 1 : 0;
 
         if (chan.reliable_length == 0 && chan.message.cursize != 0) {
             System.arraycopy(chan.message_buf, 0, chan.reliable_buf, 0,

--- a/qcommon/src/main/java/jake2/qcommon/network/Netchan.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/Netchan.java
@@ -39,10 +39,13 @@ import jake2.qcommon.util.Lib;
 public final class Netchan {
 
     /*
-     * 
-     * packet header ------------- 31 sequence 1 does this message contains a
-     * reliable payload 31 acknowledge sequence 1 acknowledge receipt of
-     * even/odd message 16 qport
+     * packet header
+     * -------------
+     * 31 sequence
+     * 1 does this message contains a reliable payload
+     * 31 acknowledge sequence
+     * 1 acknowledge receipt of * even/odd message
+     * 16 qport
      * 
      * The remote connection never knows if it missed a reliable message, the
      * local side detects that it has been dropped by seeing a sequence
@@ -55,7 +58,7 @@ public final class Netchan {
      * to get there.
      * 
      * if the sequence number is -1, the packet should be handled without a
-     * netcon
+     * netcon (Connectionless/out-of-band packet)
      * 
      * The reliable message can be added to at any time by doing MSG_Write*
      * (&netchan.message, <data>).
@@ -113,7 +116,7 @@ public final class Netchan {
     }
 
     private static final byte send_buf[] = new byte[Defines.MAX_MSGLEN];
-    private static final sizebuf_t buffer = new sizebuf_t();
+    private static final sizebuf_t packet = new sizebuf_t();
 
     /**
      * OutOfBandPrint
@@ -122,13 +125,13 @@ public final class Netchan {
         String msg = cmd.name() + payload;
 
         // write the packet header
-        buffer.init(send_buf, Defines.MAX_MSGLEN);
+        packet.init(send_buf, Defines.MAX_MSGLEN);
 
-        buffer.writeInt(-1); // -1 sequence means connectionless (out of band)
-        buffer.writeBytes(Lib.stringToBytes(msg), msg.length());
+        packet.writeInt(-1); // -1 sequence means connectionless (out of band)
+        packet.writeBytes(Lib.stringToBytes(msg), msg.length());
 
         // send the datagram
-        NET.SendPacket(net_socket, buffer.cursize, buffer.data, adr);
+        NET.SendPacket(net_socket, packet.cursize, packet.data, adr);
     }
 
     /**
@@ -143,8 +146,8 @@ public final class Netchan {
         chan.incoming_sequence = 0;
         chan.outgoing_sequence = 1;
 
-        chan.message.init(chan.message_buf, chan.message_buf.length);
-        chan.message.allowoverflow = true;
+        chan.reliable.init(chan.reliable_data, chan.reliable_data.length);
+        chan.reliable.allowoverflow = true;
     }
 
 
@@ -155,10 +158,10 @@ public final class Netchan {
      * A 0 length will still generate a packet and deal with the reliable
      * messages.
      */
-    public static void Transmit(netchan_t chan, int length, byte data[]) {
+    public static void Transmit(netchan_t chan, int length, byte[] unreliableData) {
 
         // check for message overflow
-        if (chan.message.overflowed) {
+        if (chan.reliable.overflowed) {
             chan.fatal_error = true;
             Com.Printf(chan.remote_address.toString()
                     + ":Outgoing message overflow\n");
@@ -167,56 +170,55 @@ public final class Netchan {
 
         int send_reliable = chan.needReliable() ? 1 : 0;
 
-        if (chan.reliable_length == 0 && chan.message.cursize != 0) {
-            System.arraycopy(chan.message_buf, 0, chan.reliable_buf, 0,
-                    chan.message.cursize);
-            chan.reliable_length = chan.message.cursize;
-            chan.message.cursize = 0;
+        if (chan.reliable_length == 0 && chan.reliable.cursize != 0) {
+            System.arraycopy(chan.reliable_data, 0, chan.reliable_buf, 0, chan.reliable.cursize);
+            chan.reliable_length = chan.reliable.cursize;
+            chan.reliable.cursize = 0;
             chan.reliable_sequence ^= 1;
         }
 
-        // write the packet header
-        buffer.init(send_buf, send_buf.length);
+        packet.init(send_buf, send_buf.length);
 
+        // write the packet header
         int sequence = (chan.outgoing_sequence & ~(1 << 31)) | (send_reliable << 31);
         int sequenceAck = (chan.incoming_sequence & ~(1 << 31)) | (chan.incoming_reliable_sequence << 31);
 
         chan.outgoing_sequence++;
         chan.last_sent = (int) Globals.curtime;
 
-        buffer.writeInt(sequence);
-        buffer.writeInt(sequenceAck);
+        packet.writeInt(sequence);
+        packet.writeInt(sequenceAck);
 
         // send the qport if we are a client
         if (chan.sock == Defines.NS_CLIENT)
-            buffer.writeShort((int) qport.value);
+            packet.writeShort((int) qport.value);
 
         // copy the reliable message to the packet first
         if (send_reliable != 0) {
-            buffer.writeBytes(chan.reliable_buf, chan.reliable_length);
+            packet.writeBytes(chan.reliable_buf, chan.reliable_length);
             chan.last_reliable_sequence = chan.outgoing_sequence;
         }
 
         // add the unreliable part if space is available
-        if (buffer.maxsize - buffer.cursize >= length)
-            buffer.writeBytes(data, length);
+        if (packet.maxsize - packet.cursize >= length)
+            packet.writeBytes(unreliableData, length);
         else
             Com.Printf("Netchan_Transmit: dumped unreliable\n");
 
         // send the datagram
-        NET.SendPacket(chan.sock, buffer.cursize, buffer.data, chan.remote_address);
+        NET.SendPacket(chan.sock, packet.cursize, packet.data, chan.remote_address);
 
         if (showpackets.value != 0) {
             if (send_reliable != 0)
                 Com.Printf(
-                        "send " + buffer.cursize + " : s="
+                        "send " + packet.cursize + " : s="
                                 + (chan.outgoing_sequence - 1) + " reliable="
                                 + chan.reliable_sequence + " ack="
                                 + chan.incoming_sequence + " rack="
                                 + chan.incoming_reliable_sequence + "\n");
             else
                 Com.Printf(
-                        "send " + buffer.cursize + " : s="
+                        "send " + packet.cursize + " : s="
                                 + (chan.outgoing_sequence - 1) + " ack="
                                 + chan.incoming_sequence + " rack="
                                 + chan.incoming_reliable_sequence + "\n");

--- a/qcommon/src/main/java/jake2/qcommon/network/netchan_t.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/netchan_t.java
@@ -23,7 +23,10 @@
 package jake2.qcommon.network;
 
 import jake2.qcommon.Defines;
-import jake2.qcommon.sizebuf_t;
+import jake2.qcommon.network.messages.NetworkMessage;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 public class netchan_t {
 
@@ -57,13 +60,10 @@ public class netchan_t {
 
     public int last_reliable_sequence; // sequence number of last send
 
-    //	   reliable staging and holding areas
-    public sizebuf_t reliable = new sizebuf_t(); // writing buffer to send to
-                                                // server
-
-    public byte reliable_data[] = new byte[Defines.MAX_MSGLEN - 16]; // leave
-                                                                   // space for
-                                                                   // header
+    // reliable staging and holding areas
+    // writing buffer to send to server
+    // max size: Defines.MAX_MSGLEN - 16: leave space for header
+    public Collection<NetworkMessage> reliable = new ArrayList<>();
 
     //	   message is copied to this buffer when it is first transfered
     public int reliable_length;
@@ -85,7 +85,7 @@ public class netchan_t {
         boolean send_reliable = incoming_acknowledged > last_reliable_sequence && incoming_reliable_acknowledged != reliable_sequence;
 
         // if the reliable transmit buffer is empty, copy the current message out
-        if (reliable_length == 0 && reliable.cursize != 0) {
+        if (reliable_length == 0 && reliable.size() != 0) {
             send_reliable = true;
         }
 
@@ -97,9 +97,7 @@ public class netchan_t {
         sock = dropped = last_received = last_sent = 0;
         remote_address = new netadr_t();
         qport = incoming_sequence = incoming_acknowledged = incoming_reliable_acknowledged = incoming_reliable_sequence = outgoing_sequence = reliable_sequence = last_reliable_sequence = 0;
-        reliable = new sizebuf_t();
-
-        reliable_data = new byte[Defines.MAX_MSGLEN - 16];
+        reliable.clear();
 
         reliable_length = 0;
         reliable_buf = new byte[Defines.MAX_MSGLEN - 16];

--- a/qcommon/src/main/java/jake2/qcommon/network/netchan_t.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/netchan_t.java
@@ -60,9 +60,11 @@ public class netchan_t {
 
     public int last_reliable_sequence; // sequence number of last send
 
-    // reliable staging and holding areas
-    // writing buffer to send to server
-    // max size: Defines.MAX_MSGLEN - 16: leave space for header
+    /**
+     * Reliable staging and holding areas, writing buffer to send to server.
+     * Overall size of the messages in bytes should not exceed Defines.MAX_MSGLEN - 16 (some space for header is reserved), otherwise connection will be closed.
+     * See @{link jake2.qcommon.network.Netchan#Transmit}
+     */
     public Collection<NetworkMessage> reliable = new ArrayList<>();
 
     //	   message is copied to this buffer when it is first transfered

--- a/qcommon/src/main/java/jake2/qcommon/network/netchan_t.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/netchan_t.java
@@ -69,8 +69,28 @@ public class netchan_t {
     public int reliable_length;
 
     public byte reliable_buf[] = new byte[Defines.MAX_MSGLEN - 16]; // unpcked
-                                                                    // reliable
-                                                                    // message
+
+    /**
+     * Netchan_CanReliable. Returns true if the last reliable message has acked.
+     */
+    public boolean canReliable() {
+        return reliable_length == 0; // waiting for ack
+    }
+
+    /**
+     * Netchan_NeedReliable
+     */
+    public boolean needReliable() {
+        // if the remote side dropped the last reliable message, resend it
+        boolean send_reliable = incoming_acknowledged > last_reliable_sequence && incoming_reliable_acknowledged != reliable_sequence;
+
+        // if the reliable transmit buffer is empty, copy the current message out
+        if (reliable_length == 0 && message.cursize != 0) {
+            send_reliable = true;
+        }
+
+        return send_reliable;
+    }
 
     //ok.
     public void clear() {

--- a/qcommon/src/main/java/jake2/qcommon/network/netchan_t.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/netchan_t.java
@@ -58,10 +58,10 @@ public class netchan_t {
     public int last_reliable_sequence; // sequence number of last send
 
     //	   reliable staging and holding areas
-    public sizebuf_t message = new sizebuf_t(); // writing buffer to send to
+    public sizebuf_t reliable = new sizebuf_t(); // writing buffer to send to
                                                 // server
 
-    public byte message_buf[] = new byte[Defines.MAX_MSGLEN - 16]; // leave
+    public byte reliable_data[] = new byte[Defines.MAX_MSGLEN - 16]; // leave
                                                                    // space for
                                                                    // header
 
@@ -85,7 +85,7 @@ public class netchan_t {
         boolean send_reliable = incoming_acknowledged > last_reliable_sequence && incoming_reliable_acknowledged != reliable_sequence;
 
         // if the reliable transmit buffer is empty, copy the current message out
-        if (reliable_length == 0 && message.cursize != 0) {
+        if (reliable_length == 0 && reliable.cursize != 0) {
             send_reliable = true;
         }
 
@@ -97,9 +97,9 @@ public class netchan_t {
         sock = dropped = last_received = last_sent = 0;
         remote_address = new netadr_t();
         qport = incoming_sequence = incoming_acknowledged = incoming_reliable_acknowledged = incoming_reliable_sequence = outgoing_sequence = reliable_sequence = last_reliable_sequence = 0;
-        message = new sizebuf_t();
+        reliable = new sizebuf_t();
 
-        message_buf = new byte[Defines.MAX_MSGLEN - 16];
+        reliable_data = new byte[Defines.MAX_MSGLEN - 16];
 
         reliable_length = 0;
         reliable_buf = new byte[Defines.MAX_MSGLEN - 16];

--- a/server/src/main/java/jake2/server/GameImportsImpl.java
+++ b/server/src/main/java/jake2/server/GameImportsImpl.java
@@ -738,9 +738,7 @@ public class GameImportsImpl implements GameImports {
             }
 
             if (reliable) {
-                msg.writeTo(sv.multicast);
-                client.netchan.reliable.writeBytes(sv.multicast.data, sv.multicast.cursize);
-                sv.multicast.clear();
+                client.netchan.reliable.add(msg);
             } else
                 client.unreliable.add(msg);
         }

--- a/server/src/main/java/jake2/server/GameImportsImpl.java
+++ b/server/src/main/java/jake2/server/GameImportsImpl.java
@@ -31,6 +31,7 @@ import jake2.qcommon.filesystem.FS;
 import jake2.qcommon.filesystem.QuakeFile;
 import jake2.qcommon.network.MulticastTypes;
 import jake2.qcommon.network.NET;
+import jake2.qcommon.network.messages.NetworkMessage;
 import jake2.qcommon.network.messages.server.PrintCenterMessage;
 import jake2.qcommon.network.messages.server.ServerMessage;
 import jake2.qcommon.network.messages.server.StuffTextMessage;
@@ -144,8 +145,7 @@ public class GameImportsImpl implements GameImports {
         if (n < 1 || n > sv_game.gameImports.serverMain.getClients().size())
             return; // Com_Error (ERR_DROP, "centerprintf to a non-client");
 
-        new PrintCenterMessage(s).writeTo(sv.multicast);
-        sv_game.PF_Unicast(ent.index, true);
+        sv_game.PF_Unicast(ent.index, true, new PrintCenterMessage(s));
     }
 
     @Override
@@ -252,15 +252,6 @@ public class GameImportsImpl implements GameImports {
     @Override
     public void Pmove(pmove_t pmove) {
         PMove.Pmove(pmove);
-    }
-
-    /*
-     player movement code common with client prediction
-     network messaging
-    */
-    @Override
-    public void multicast(float[] origin, MulticastTypes to) {
-        SV_Multicast(origin, to);
     }
 
     /**
@@ -587,8 +578,7 @@ public class GameImportsImpl implements GameImports {
         if (sv.state == ServerStates.SS_DEAD)
             return;
 
-        new StuffTextMessage(s).writeTo(sv.multicast);
-        SV_Multicast(null, MulticastTypes.MULTICAST_ALL_R);
+        SV_Multicast(null, MulticastTypes.MULTICAST_ALL_R, new StuffTextMessage(s));
     }
 
     void SV_WriteLevelFile() {
@@ -678,7 +668,7 @@ public class GameImportsImpl implements GameImports {
      * MULTICAST_PVS	send to clients potentially visible from org
      * MULTICAST_PHS	send to clients potentially hearable from org
      */
-    private void SV_Multicast(float[] origin, MulticastTypes to) {
+    private void SV_Multicast(float[] origin, MulticastTypes to, NetworkMessage msg) {
         byte mask[];
         int leafnum, cluster;
         int j;
@@ -747,24 +737,23 @@ public class GameImportsImpl implements GameImports {
                     continue;
             }
 
-            if (reliable)
+            if (reliable) {
+                msg.writeTo(sv.multicast);
                 client.netchan.reliable.writeBytes(sv.multicast.data, sv.multicast.cursize);
-            else
-                client.unreliable.writeBytes(sv.multicast.data, sv.multicast.cursize);
+                sv.multicast.clear();
+            } else
+                client.unreliable.add(msg);
         }
 
-        sv.multicast.clear();
     }
 
     @Override
     public void multicastMessage(float[] origin, ServerMessage msg, MulticastTypes to) {
-        msg.writeTo(sv.multicast);
-        SV_Multicast(origin, to);
+        SV_Multicast(origin, to, msg);
     }
 
     @Override
     public void unicastMessage(int index, ServerMessage msg, boolean reliable) {
-        msg.writeTo(sv.multicast);
-        sv_game.PF_Unicast(index, reliable);
+        sv_game.PF_Unicast(index, reliable, msg);
     }
 }

--- a/server/src/main/java/jake2/server/GameImportsImpl.java
+++ b/server/src/main/java/jake2/server/GameImportsImpl.java
@@ -748,9 +748,9 @@ public class GameImportsImpl implements GameImports {
             }
 
             if (reliable)
-                client.netchan.message.writeBytes(sv.multicast.data, sv.multicast.cursize);
+                client.netchan.reliable.writeBytes(sv.multicast.data, sv.multicast.cursize);
             else
-                client.datagram.writeBytes(sv.multicast.data, sv.multicast.cursize);
+                client.unreliable.writeBytes(sv.multicast.data, sv.multicast.cursize);
         }
 
         sv.multicast.clear();

--- a/server/src/main/java/jake2/server/SV_GAME.java
+++ b/server/src/main/java/jake2/server/SV_GAME.java
@@ -52,10 +52,7 @@ public class SV_GAME {
         client_t client = gameImports.serverMain.getClients().get(p - 1);
 
         if (reliable) {
-            msg.writeTo(gameImports.sv.multicast);
-            client.netchan.reliable.writeBytes(gameImports.sv.multicast.data, gameImports.sv.multicast.cursize);
-            gameImports.sv.multicast.clear();
-
+            client.netchan.reliable.add(msg);
         } else
             client.unreliable.add(msg);
 
@@ -135,10 +132,9 @@ public class SV_GAME {
         // change the string in sv
         gameImports.sv.configstrings[index] = val;
 
-        if (gameImports.sv.state != ServerStates.SS_LOADING) { // send the update to
-                                                      // everyone
-            gameImports.sv.multicast.clear();
-            gameImports.multicastMessage(Globals.vec3_origin, new ConfigStringMessage(index, val), MulticastTypes.MULTICAST_ALL_R);
+        if (gameImports.sv.state != ServerStates.SS_LOADING) {
+            // send the update to everyone
+            gameImports.multicastMessage(null, new ConfigStringMessage(index, val), MulticastTypes.MULTICAST_ALL_R);
         }
     }
 

--- a/server/src/main/java/jake2/server/SV_GAME.java
+++ b/server/src/main/java/jake2/server/SV_GAME.java
@@ -26,6 +26,7 @@ import jake2.qcommon.*;
 import jake2.qcommon.exec.Cvar;
 import jake2.qcommon.filesystem.FS;
 import jake2.qcommon.network.MulticastTypes;
+import jake2.qcommon.network.messages.NetworkMessage;
 import jake2.qcommon.network.messages.server.ConfigStringMessage;
 import jake2.qcommon.util.Math3D;
 
@@ -43,21 +44,21 @@ public class SV_GAME {
      * 
      * Sends the contents of the mutlicast buffer to a single client.
      */
-    public void PF_Unicast(int p, boolean reliable) {
+    public void PF_Unicast(int p, boolean reliable, NetworkMessage msg) {
 
         if (p < 1 || p > gameImports.serverMain.getClients().size())
             return;
 
         client_t client = gameImports.serverMain.getClients().get(p - 1);
 
-        if (reliable)
-            client.netchan.reliable.writeBytes(gameImports.sv.multicast.data,
-                    gameImports.sv.multicast.cursize);
-        else
-            client.unreliable.writeBytes(gameImports.sv.multicast.data,
-                    gameImports.sv.multicast.cursize);
+        if (reliable) {
+            msg.writeTo(gameImports.sv.multicast);
+            client.netchan.reliable.writeBytes(gameImports.sv.multicast.data, gameImports.sv.multicast.cursize);
+            gameImports.sv.multicast.clear();
 
-        gameImports.sv.multicast.clear();
+        } else
+            client.unreliable.add(msg);
+
     }
 
     /**

--- a/server/src/main/java/jake2/server/SV_GAME.java
+++ b/server/src/main/java/jake2/server/SV_GAME.java
@@ -51,10 +51,10 @@ public class SV_GAME {
         client_t client = gameImports.serverMain.getClients().get(p - 1);
 
         if (reliable)
-            client.netchan.message.writeBytes(gameImports.sv.multicast.data,
+            client.netchan.reliable.writeBytes(gameImports.sv.multicast.data,
                     gameImports.sv.multicast.cursize);
         else
-            client.datagram.writeBytes(gameImports.sv.multicast.data,
+            client.unreliable.writeBytes(gameImports.sv.multicast.data,
                     gameImports.sv.multicast.cursize);
 
         gameImports.sv.multicast.clear();

--- a/server/src/main/java/jake2/server/SV_MAIN.java
+++ b/server/src/main/java/jake2/server/SV_MAIN.java
@@ -904,23 +904,24 @@ public class SV_MAIN implements JakeServer {
      */
     private void SV_FinalMessage(String message, boolean reconnect) {
 
-        Globals.net_message.clear();
-        new PrintMessage(Defines.PRINT_HIGH, message).writeTo(Globals.net_message);
+        sizebuf_t buffer = new sizebuf_t();
+        buffer.init(new byte[MAX_MSGLEN], MAX_MSGLEN);
+        new PrintMessage(Defines.PRINT_HIGH, message).writeTo(buffer);
 
         if (reconnect)
-            new ReconnectMessage().writeTo(Globals.net_message);
+            new ReconnectMessage().writeTo(buffer);
         else
-            new DisconnectMessage().writeTo(Globals.net_message);
+            new DisconnectMessage().writeTo(buffer);
 
         // send it twice
         // stagger the packets to crutch operating system limited buffers
         for (client_t cl : clients) {
             if (cl.state == ClientStates.CS_CONNECTED || cl.state == ClientStates.CS_SPAWNED)
-                Netchan.Transmit(cl.netchan, Globals.net_message.cursize, Globals.net_message.data);
+                Netchan.Transmit(cl.netchan, buffer.cursize, buffer.data);
         }
         for (client_t cl : clients) {
             if (cl.state == ClientStates.CS_CONNECTED || cl.state == ClientStates.CS_SPAWNED)
-                Netchan.Transmit(cl.netchan, Globals.net_message.cursize, Globals.net_message.data);
+                Netchan.Transmit(cl.netchan, buffer.cursize, buffer.data);
         }
     }
 

--- a/server/src/main/java/jake2/server/SV_SEND.java
+++ b/server/src/main/java/jake2/server/SV_SEND.java
@@ -54,7 +54,7 @@ public class SV_SEND {
 	public static void SV_ClientPrintf(client_t cl, int level, String s) {
 
 		if (level >= cl.messagelevel) {
-			new PrintMessage(level, s).writeTo(cl.netchan.reliable);
+			cl.netchan.reliable.add(new PrintMessage(level, s));
 		}
 	}
 

--- a/server/src/main/java/jake2/server/SV_USER.java
+++ b/server/src/main/java/jake2/server/SV_USER.java
@@ -26,6 +26,7 @@ import jake2.qcommon.*;
 import jake2.qcommon.exec.Cbuf;
 import jake2.qcommon.exec.Cvar;
 import jake2.qcommon.filesystem.FS;
+import jake2.qcommon.network.messages.NetworkMessage;
 import jake2.qcommon.network.messages.client.StringCmdMessage;
 import jake2.qcommon.network.messages.server.*;
 import jake2.qcommon.util.Lib;
@@ -96,7 +97,15 @@ class SV_USER {
             playernum = gameImports.sv_client.edict.index - 1;
 
 
-        new ServerDataMessage(Defines.PROTOCOL_VERSION, gameImports.spawncount, gameImports.sv.isDemo, gamedir, playernum, gameImports.sv.configstrings[Defines.CS_NAME]).writeTo(gameImports.sv_client.netchan.reliable);
+        gameImports.sv_client.netchan.reliable.add(
+                new ServerDataMessage(
+                        Defines.PROTOCOL_VERSION,
+                        gameImports.spawncount,
+                        gameImports.sv.isDemo,
+                        gamedir,
+                        playernum,
+                        gameImports.sv.configstrings[Defines.CS_NAME]
+                ));
         //
         // game server
         // 
@@ -108,7 +117,7 @@ class SV_USER {
             gameImports.sv_client.lastcmd = new usercmd_t();
 
             // begin fetching configstrings
-            new StuffTextMessage(String.format("cmd %s %d 0", StringCmdMessage.CONFIG_STRINGS, gameImports.spawncount)).writeTo(gameImports.sv_client.netchan.reliable);
+            gameImports.sv_client.netchan.reliable.add(new StuffTextMessage(String.format("cmd %s %d 0", StringCmdMessage.CONFIG_STRINGS, gameImports.spawncount)));
         }
     }
 
@@ -135,9 +144,12 @@ class SV_USER {
         int start = args.size() >= 3 ? Lib.atoi(args.get(2)) : 0;
 
         // write a packet full of data
-        while (gameImports.sv_client.netchan.reliable.cursize < Defines.MAX_MSGLEN / 2 && start < Defines.MAX_CONFIGSTRINGS) {
+        int currentReliableSize = gameImports.sv_client.netchan.reliable.stream().mapToInt(NetworkMessage::getSize).sum();
+        while (currentReliableSize < Defines.MAX_MSGLEN / 2 && start < Defines.MAX_CONFIGSTRINGS) {
             if (gameImports.sv.configstrings[start] != null && gameImports.sv.configstrings[start].length() != 0) {
-                new ConfigStringMessage(start, gameImports.sv.configstrings[start]).writeTo(gameImports.sv_client.netchan.reliable);
+                final ConfigStringMessage config = new ConfigStringMessage(start, gameImports.sv.configstrings[start]);
+                currentReliableSize += config.getSize();
+                gameImports.sv_client.netchan.reliable.add(config);
             }
             start++;
         }
@@ -150,7 +162,7 @@ class SV_USER {
         } else {
             nextCmd = String.format("cmd %s %d %d", StringCmdMessage.CONFIG_STRINGS, gameImports.spawncount, start);
         }
-        new StuffTextMessage(nextCmd).writeTo(gameImports.sv_client.netchan.reliable);
+        gameImports.sv_client.netchan.reliable.add(new StuffTextMessage(nextCmd));
     }
 
     /*
@@ -180,10 +192,13 @@ class SV_USER {
         entity_state_t nullstate = new entity_state_t(null);
 
         // write a packet full of data
-        while (gameImports.sv_client.netchan.reliable.cursize < Defines.MAX_MSGLEN / 2 && start < Defines.MAX_EDICTS) {
+        int currentReliableSize = gameImports.sv_client.netchan.reliable.stream().mapToInt(NetworkMessage::getSize).sum();
+        while (currentReliableSize < Defines.MAX_MSGLEN / 2 && start < Defines.MAX_EDICTS) {
             entity_state_t base = gameImports.sv.baselines[start];
             if (base.modelindex != 0 || base.sound != 0 || base.effects != 0) {
-                new SpawnBaselineMessage(base).writeTo(gameImports.sv_client.netchan.reliable);
+                final SpawnBaselineMessage spawn = new SpawnBaselineMessage(base);
+                currentReliableSize += spawn.getSize();
+                gameImports.sv_client.netchan.reliable.add(spawn);
             }
             start++;
         }
@@ -197,7 +212,7 @@ class SV_USER {
             // continue from where we finished
             nextCmd = String.format("cmd %s %d %d", StringCmdMessage.BASELINES, gameImports.spawncount, start);
         }
-        new StuffTextMessage(nextCmd).writeTo(gameImports.sv_client.netchan.reliable);
+        gameImports.sv_client.netchan.reliable.add(new StuffTextMessage(nextCmd));
     }
 
     /*
@@ -244,7 +259,7 @@ class SV_USER {
 
         byte[] data = new byte[packet];
         System.arraycopy(gameImports.sv_client.download, gameImports.sv_client.downloadcount - packet, data, 0, packet);
-        new DownloadMessage(data, percent).writeTo(gameImports.sv_client.netchan.reliable);
+        gameImports.sv_client.netchan.reliable.add(new DownloadMessage(data, percent));
 
         if (gameImports.sv_client.downloadcount == gameImports.sv_client.downloadsize) {
             gameImports.sv_client.download = null;
@@ -287,7 +302,7 @@ class SV_USER {
                                               // path
 
             // refuse
-            new DownloadMessage().writeTo(gameImports.sv_client.netchan.reliable);
+            gameImports.sv_client.netchan.reliable.add(new DownloadMessage());
             return;
         }
 
@@ -312,7 +327,7 @@ class SV_USER {
             }
 
             // refuse
-            new DownloadMessage().writeTo(gameImports.sv_client.netchan.reliable);
+            gameImports.sv_client.netchan.reliable.add(new DownloadMessage());
             return;
         }
 

--- a/server/src/main/java/jake2/server/SV_USER.java
+++ b/server/src/main/java/jake2/server/SV_USER.java
@@ -96,7 +96,7 @@ class SV_USER {
             playernum = gameImports.sv_client.edict.index - 1;
 
 
-        new ServerDataMessage(Defines.PROTOCOL_VERSION, gameImports.spawncount, gameImports.sv.isDemo, gamedir, playernum, gameImports.sv.configstrings[Defines.CS_NAME]).writeTo(gameImports.sv_client.netchan.message);
+        new ServerDataMessage(Defines.PROTOCOL_VERSION, gameImports.spawncount, gameImports.sv.isDemo, gamedir, playernum, gameImports.sv.configstrings[Defines.CS_NAME]).writeTo(gameImports.sv_client.netchan.reliable);
         //
         // game server
         // 
@@ -108,7 +108,7 @@ class SV_USER {
             gameImports.sv_client.lastcmd = new usercmd_t();
 
             // begin fetching configstrings
-            new StuffTextMessage(String.format("cmd %s %d 0", StringCmdMessage.CONFIG_STRINGS, gameImports.spawncount)).writeTo(gameImports.sv_client.netchan.message);
+            new StuffTextMessage(String.format("cmd %s %d 0", StringCmdMessage.CONFIG_STRINGS, gameImports.spawncount)).writeTo(gameImports.sv_client.netchan.reliable);
         }
     }
 
@@ -135,9 +135,9 @@ class SV_USER {
         int start = args.size() >= 3 ? Lib.atoi(args.get(2)) : 0;
 
         // write a packet full of data
-        while (gameImports.sv_client.netchan.message.cursize < Defines.MAX_MSGLEN / 2 && start < Defines.MAX_CONFIGSTRINGS) {
+        while (gameImports.sv_client.netchan.reliable.cursize < Defines.MAX_MSGLEN / 2 && start < Defines.MAX_CONFIGSTRINGS) {
             if (gameImports.sv.configstrings[start] != null && gameImports.sv.configstrings[start].length() != 0) {
-                new ConfigStringMessage(start, gameImports.sv.configstrings[start]).writeTo(gameImports.sv_client.netchan.message);
+                new ConfigStringMessage(start, gameImports.sv.configstrings[start]).writeTo(gameImports.sv_client.netchan.reliable);
             }
             start++;
         }
@@ -150,7 +150,7 @@ class SV_USER {
         } else {
             nextCmd = String.format("cmd %s %d %d", StringCmdMessage.CONFIG_STRINGS, gameImports.spawncount, start);
         }
-        new StuffTextMessage(nextCmd).writeTo(gameImports.sv_client.netchan.message);
+        new StuffTextMessage(nextCmd).writeTo(gameImports.sv_client.netchan.reliable);
     }
 
     /*
@@ -180,10 +180,10 @@ class SV_USER {
         entity_state_t nullstate = new entity_state_t(null);
 
         // write a packet full of data
-        while (gameImports.sv_client.netchan.message.cursize < Defines.MAX_MSGLEN / 2 && start < Defines.MAX_EDICTS) {
+        while (gameImports.sv_client.netchan.reliable.cursize < Defines.MAX_MSGLEN / 2 && start < Defines.MAX_EDICTS) {
             entity_state_t base = gameImports.sv.baselines[start];
             if (base.modelindex != 0 || base.sound != 0 || base.effects != 0) {
-                new SpawnBaselineMessage(base).writeTo(gameImports.sv_client.netchan.message);
+                new SpawnBaselineMessage(base).writeTo(gameImports.sv_client.netchan.reliable);
             }
             start++;
         }
@@ -197,7 +197,7 @@ class SV_USER {
             // continue from where we finished
             nextCmd = String.format("cmd %s %d %d", StringCmdMessage.BASELINES, gameImports.spawncount, start);
         }
-        new StuffTextMessage(nextCmd).writeTo(gameImports.sv_client.netchan.message);
+        new StuffTextMessage(nextCmd).writeTo(gameImports.sv_client.netchan.reliable);
     }
 
     /*
@@ -244,7 +244,7 @@ class SV_USER {
 
         byte[] data = new byte[packet];
         System.arraycopy(gameImports.sv_client.download, gameImports.sv_client.downloadcount - packet, data, 0, packet);
-        new DownloadMessage(data, percent).writeTo(gameImports.sv_client.netchan.message);
+        new DownloadMessage(data, percent).writeTo(gameImports.sv_client.netchan.reliable);
 
         if (gameImports.sv_client.downloadcount == gameImports.sv_client.downloadsize) {
             gameImports.sv_client.download = null;
@@ -287,7 +287,7 @@ class SV_USER {
                                               // path
 
             // refuse
-            new DownloadMessage().writeTo(gameImports.sv_client.netchan.message);
+            new DownloadMessage().writeTo(gameImports.sv_client.netchan.reliable);
             return;
         }
 
@@ -312,7 +312,7 @@ class SV_USER {
             }
 
             // refuse
-            new DownloadMessage().writeTo(gameImports.sv_client.netchan.message);
+            new DownloadMessage().writeTo(gameImports.sv_client.netchan.reliable);
             return;
         }
 

--- a/server/src/main/java/jake2/server/client_t.java
+++ b/server/src/main/java/jake2/server/client_t.java
@@ -22,8 +22,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 package jake2.server;
 
-import jake2.qcommon.*;
+import jake2.qcommon.Defines;
+import jake2.qcommon.edict_t;
 import jake2.qcommon.network.netchan_t;
+import jake2.qcommon.sizebuf_t;
+import jake2.qcommon.usercmd_t;
 
 /**
  * Server side representation of client.
@@ -67,7 +70,7 @@ public class client_t {
 
 	// The datagram is written to by sound calls, prints, temp ents, etc.
 	// It can be harmlessly overflowed.
-	sizebuf_t datagram = new sizebuf_t();
+	sizebuf_t unreliable = new sizebuf_t();
 	byte datagram_buf[] = new byte[Defines.MAX_MSGLEN];
 
 	client_frame_t frames[] = new client_frame_t[Defines.UPDATE_BACKUP]; // updates can be delta'd from here

--- a/server/src/main/java/jake2/server/client_t.java
+++ b/server/src/main/java/jake2/server/client_t.java
@@ -24,9 +24,12 @@ package jake2.server;
 
 import jake2.qcommon.Defines;
 import jake2.qcommon.edict_t;
+import jake2.qcommon.network.messages.NetworkMessage;
 import jake2.qcommon.network.netchan_t;
-import jake2.qcommon.sizebuf_t;
 import jake2.qcommon.usercmd_t;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 /**
  * Server side representation of client.
@@ -68,10 +71,9 @@ public class client_t {
 
 	int messagelevel; // for filtering printed messages
 
-	// The datagram is written to by sound calls, prints, temp ents, etc.
+	// This collection (the datagram) is written to by sound calls, prints, temp ents, etc.
 	// It can be harmlessly overflowed.
-	sizebuf_t unreliable = new sizebuf_t();
-	byte datagram_buf[] = new byte[Defines.MAX_MSGLEN];
+	Collection<NetworkMessage> unreliable = new ArrayList<>();
 
 	client_frame_t frames[] = new client_frame_t[Defines.UPDATE_BACKUP]; // updates can be delta'd from here
 

--- a/server/src/main/java/jake2/server/server_t.java
+++ b/server/src/main/java/jake2/server/server_t.java
@@ -22,7 +22,10 @@
 // $Id: server_t.java,v 1.2 2004-09-22 19:22:12 salomo Exp $
 package jake2.server;
 
-import jake2.qcommon.*;
+import jake2.qcommon.Defines;
+import jake2.qcommon.ServerStates;
+import jake2.qcommon.cmodel_t;
+import jake2.qcommon.entity_state_t;
 
 class server_t {
 
@@ -53,11 +56,4 @@ class server_t {
     String[] configstrings = new String[Defines.MAX_CONFIGSTRINGS];
 
     entity_state_t[] baselines = new entity_state_t[Defines.MAX_EDICTS];
-
-    // the multicast buffer is used to send a message to a set of clients
-    // it is only used to marshall data until SV_Multicast is called
-    sizebuf_t multicast = new sizebuf_t();
-
-    byte[] multicast_buf = new byte[Defines.MAX_MSGLEN];
-
 }


### PR DESCRIPTION
Mostly you will see changes like `NetworkMessage.writeTo(buffer)` -> `messages.add(NetworkMessage)`
But also important was to get rid of datagram/multicast and other temp byte buffers and defer message serialization to the very moment they are ready to be transmitted over the network (`Netchan.Transmit`)