### PR TITLE
 Create new GameImports/GameExports instance every time new map is created

### DIFF
--- a/client/src/main/java/jake2/client/CL_parse.java
+++ b/client/src/main/java/jake2/client/CL_parse.java
@@ -450,7 +450,6 @@ public class CL_parse {
      * ================ CL_ParseConfigString ================
      */
     public static void ParseConfigString(ConfigStringMessage configMsg) {
-        Com.Printf("Received " + configMsg + "\n");
         if (configMsg.index < 0 || configMsg.index >= Defines.MAX_CONFIGSTRINGS)
             Com.Error(Defines.ERR_DROP, "configstring > MAX_CONFIGSTRINGS");
 

--- a/fullgame/src/test/java/jake2/server/GameImportsTest.java
+++ b/fullgame/src/test/java/jake2/server/GameImportsTest.java
@@ -23,7 +23,7 @@ public class GameImportsTest {
 
     @Test
     public void runEmptyInstance() {
-        GameImportsImpl testInstance = new SV_MAIN().createGameInstance();
+        GameImportsImpl testInstance = new SV_MAIN().createGameInstance(new ChangeMapInfo("test.bsp", false, false));
 
         testInstance.SV_RunGameFrame();
 
@@ -63,7 +63,7 @@ public class GameImportsTest {
 
     @Test
     public void shutDownEmptyInstance() {
-        GameImportsImpl testInstance = new SV_MAIN().createGameInstance();
+        GameImportsImpl testInstance = new SV_MAIN().createGameInstance(new ChangeMapInfo("test.bsp", false, false));
 
         Cbuf.AddText("sv_shutdown");
         testInstance.SV_RunGameFrame();

--- a/game/src/main/java/jake2/game/GameExportsImpl.java
+++ b/game/src/main/java/jake2/game/GameExportsImpl.java
@@ -211,7 +211,7 @@ public class GameExportsImpl implements GameExports {
      * in the edict structure, so it needs to be mirrored out to the client
      * structure before all the edicts are wiped.
      *
-     * Restored in PlayerClient#FetchClientEntData() when the client
+     * Restored in PlayerClient#FetchClientEntData() when the client reconnects
      */
     @Override
     public void SaveClientData() {

--- a/game/src/main/java/jake2/game/GameExportsImpl.java
+++ b/game/src/main/java/jake2/game/GameExportsImpl.java
@@ -154,11 +154,10 @@ public class GameExportsImpl implements GameExports {
 
     /**
      * entity with index = 0 is always the worldspawn.
-     * entities with indices 1..maxclients are the players
-     * then go other stuff
+     * entities with indices 1..maxclients are the players,
+     * then goes other stuff
      */
-    // todo: make consistent with maxentities cvar
-    public SubgameEntity[] g_edicts = new SubgameEntity[Defines.MAX_EDICTS];
+    public SubgameEntity[] g_edicts;
     int num_edicts;
 
     /////////////////////////////////////
@@ -196,6 +195,8 @@ public class GameExportsImpl implements GameExports {
         gameCvars = new GameCvars(imports);
 
         CreateEdicts(gameImports.cvar("maxentities", "1024", Defines.CVAR_LATCH).value);
+
+        // fixme: should be already set in SV_MAIN
         CreateClients(gameImports.cvar("maxclients", "4", Defines.CVAR_SERVERINFO | Defines.CVAR_LATCH).value);
 
         for (int n = 0; n < Defines.MAX_EDICTS; n++) {
@@ -203,6 +204,32 @@ public class GameExportsImpl implements GameExports {
         }
 
         playerTrail = new PlayerTrail(this);
+    }
+
+    /**
+     * Some information that should be persistent, like health, is still stored
+     * in the edict structure, so it needs to be mirrored out to the client
+     * structure before all the edicts are wiped.
+     *
+     * Restored in PlayerClient#FetchClientEntData() when the client
+     */
+    @Override
+    public void SaveClientData() {
+
+        for (int i = 0; i < game.maxclients; i++) {
+            SubgameEntity ent = g_edicts[1 + i];
+            if (!ent.inuse)
+                continue;
+
+            game.clients[i].pers.health = ent.health;
+            game.clients[i].pers.max_health = ent.max_health;
+            game.clients[i].pers.savedFlags = (ent.flags & (GameDefines.FL_GODMODE | GameDefines.FL_NOTARGET | GameDefines.FL_POWER_ARMOR));
+
+            if (gameCvars.coop.value != 0) {
+                gclient_t client = ent.getClient();
+                game.clients[i].pers.score = client.resp.score;
+            }
+        }
     }
 
     // create the entities array and fill it with empty entities
@@ -990,6 +1017,7 @@ public class GameExportsImpl implements GameExports {
      * Exits a level.
      */
     private void exitLevel() {
+        Com.Printf("exiting to " + level.changemap + "\n");
         gameImports.AddCommandString("gamemap \"" + level.changemap + "\"\n");
 
         // todo: remove as not necessary, new game instance will be created anyway
@@ -1488,7 +1516,7 @@ public class GameExportsImpl implements GameExports {
         try {
 
             if (!autosave)
-                PlayerClient.SaveClientData(this);
+                SaveClientData();
 
             QuakeFile f = new QuakeFile(filename, "rw");
 
@@ -1648,6 +1676,23 @@ public class GameExportsImpl implements GameExports {
     @Override
     public int getNumEdicts() {
         return num_edicts;
+    }
+
+    @Override
+    public void fromPrevious(GameExports oldGame) {
+        GameExportsImpl oldGameImpl = (GameExportsImpl) oldGame;
+        // assert both client arrays are of the same size
+        for (int i = 0; i < oldGameImpl.game.clients.length && i < game.clients.length; i++) {
+            game.clients[i].pers.set(oldGameImpl.game.clients[i].pers);
+        }
+
+        game.serverflags = oldGameImpl.game.serverflags;
+        game.helpchanged = oldGameImpl.game.helpchanged;
+        game.helpmessage1 = oldGameImpl.game.helpmessage1;
+        game.helpmessage2 = oldGameImpl.game.helpmessage2;
+        game.autosaved = oldGameImpl.game.autosaved;
+        // spawnpoint
+
     }
 
 }

--- a/game/src/main/java/jake2/game/GameSpawn.java
+++ b/game/src/main/java/jake2/game/GameSpawn.java
@@ -1324,13 +1324,6 @@ public class GameSpawn {
         if (gameExports.gameCvars.skill.value != skill_level)
             gameExports.gameImports.cvar_forceset("skill", "" + skill_level);
 
-        PlayerClient.SaveClientData(gameExports);
-
-        gameExports.level = new level_locals_t();
-        for (int n = 0; n < gameExports.game.maxentities; n++) {
-            gameExports.g_edicts[n] = new SubgameEntity(n);
-        }
-
         gameExports.level.mapname = mapname;
         gameExports.game.spawnpoint = spawnpoint;
 

--- a/game/src/main/java/jake2/game/PlayerClient.java
+++ b/game/src/main/java/jake2/game/PlayerClient.java
@@ -528,31 +528,6 @@ public class PlayerClient {
         client.resp.coop_respawn.set(client.pers);
     }
 
-    /**
-     * Some information that should be persistant, like health, is still stored
-     * in the edict structure, so it needs to be mirrored out to the client
-     * structure before all the edicts are wiped.
-     * @param gameExports
-     */
-    public static void SaveClientData(GameExportsImpl gameExports) {
-
-        for (int i = 0; i < gameExports.game.maxclients; i++) {
-            SubgameEntity ent = gameExports.g_edicts[1 + i];
-            if (!ent.inuse)
-                continue;
-
-            gameExports.game.clients[i].pers.health = ent.health;
-            gameExports.game.clients[i].pers.max_health = ent.max_health;
-            gameExports.game.clients[i].pers.savedFlags = (ent.flags & (GameDefines.FL_GODMODE
-                    | GameDefines.FL_NOTARGET | GameDefines.FL_POWER_ARMOR));
-
-            if (gameExports.gameCvars.coop.value != 0) {
-                gclient_t client = ent.getClient();
-                gameExports.game.clients[i].pers.score = client.resp.score;
-            }
-        }
-    }
-
     public static void FetchClientEntData(SubgameEntity ent, GameExportsImpl gameExports) {
         gclient_t client = ent.getClient();
         ent.health = client.pers.health;

--- a/game/src/main/java/jake2/game/game_locals_t.java
+++ b/game/src/main/java/jake2/game/game_locals_t.java
@@ -39,11 +39,12 @@ public class game_locals_t {
 
     public String helpmessage2 = "";
 
-    public int helpchanged; // flash F1 icon if non 0, play sound
+    /**
+     * flash F1 icon if non 0, play sound, and increment only if 1, 2, or 3
+     */
+    public int helpchanged;
 
-    // and increment only if 1, 2, or 3
-
-    public gclient_t clients[] = new gclient_t[Defines.MAX_CLIENTS];
+    public gclient_t[] clients = new gclient_t[Defines.MAX_CLIENTS];
 
     // can't store spawnpoint in level, because
     // it would get overwritten by the savegame restore

--- a/qcommon/src/main/java/jake2/qcommon/GameExports.java
+++ b/qcommon/src/main/java/jake2/qcommon/GameExports.java
@@ -94,4 +94,13 @@ public interface GameExports {
     edict_t getEdict(int index);
 
     int getNumEdicts();
+
+    /**
+     * Persist whatever is required from the previous instance.
+     * @param oldGame
+     */
+    void fromPrevious(GameExports oldGame);
+
+    void SaveClientData();
+
 }

--- a/qcommon/src/main/java/jake2/qcommon/exec/Cmd.java
+++ b/qcommon/src/main/java/jake2/qcommon/exec/Cmd.java
@@ -345,8 +345,9 @@ public final class Cmd {
     }
 
     public static void ExecuteFunction(String name, String... args) {
-        if (cmd_functions.containsKey(name))
+        if (cmd_functions.containsKey(name)) {
             cmd_functions.get(name).function.execute(Arrays.asList(args));
+        }
     }
 
     public static void ExecuteFunction(String name, List<String> args) {

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/NetworkPacket.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/NetworkPacket.java
@@ -5,8 +5,8 @@ import jake2.qcommon.Defines;
 import jake2.qcommon.network.NetAddrType;
 import jake2.qcommon.network.messages.client.ClientMessage;
 import jake2.qcommon.network.messages.client.EndOfClientPacketMessage;
-import jake2.qcommon.network.messages.server.EndOfServerPacketMessage;
-import jake2.qcommon.network.messages.server.ServerMessage;
+import jake2.qcommon.network.messages.client.MoveMessage;
+import jake2.qcommon.network.messages.server.*;
 import jake2.qcommon.network.netadr_t;
 import jake2.qcommon.sizebuf_t;
 
@@ -73,6 +73,7 @@ public class NetworkPacket {
 
         if (isConnectionless()) {
             connectionlessMessage = buffer.readString();
+            Com.Printf("Network: Received " + (fromClient ? "client" : "server") + " connectionless: " + connectionlessMessage + "\n");
             if (!fromClient) {
                 switch (connectionlessMessage) {
                     case "info":
@@ -99,6 +100,9 @@ public class NetworkPacket {
             if (msg instanceof EndOfServerPacketMessage) {
                 break;
             } else if (msg != null) {
+                if (!(msg instanceof FrameHeaderMessage) && !(msg instanceof PlayerInfoMessage) && !(msg instanceof PacketEntitiesMessage)) {
+                    Com.Printf("Network: Received server msg: " + msg + "\n");
+                }
                 result.add(msg);
             }
             if (buffer.readcount > buffer.cursize) {
@@ -116,6 +120,9 @@ public class NetworkPacket {
             if (msg == null || msg instanceof EndOfClientPacketMessage) {
                 break;
             } else {
+                if (!(msg instanceof MoveMessage)) {
+                    Com.Printf("Network: Received client msg: " + msg + "\n");
+                }
                 result.add(msg);
             }
 

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/NetworkPacket.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/NetworkPacket.java
@@ -73,7 +73,7 @@ public class NetworkPacket {
 
         if (isConnectionless()) {
             connectionlessMessage = buffer.readString();
-            Com.Printf("Network: Received " + (fromClient ? "client" : "server") + " connectionless: " + connectionlessMessage + "\n");
+            Com.Printf("Network: Received from " + (fromClient ? "client" : "server") + " connectionless: " + connectionlessMessage + "\n");
             if (!fromClient) {
                 switch (connectionlessMessage) {
                     case "info":

--- a/qcommon/src/main/java/jake2/qcommon/network/messages/server/ConfigStringMessage.java
+++ b/qcommon/src/main/java/jake2/qcommon/network/messages/server/ConfigStringMessage.java
@@ -2,6 +2,8 @@ package jake2.qcommon.network.messages.server;
 
 import jake2.qcommon.sizebuf_t;
 
+import static jake2.qcommon.Defines.*;
+
 public class ConfigStringMessage extends ServerMessage {
     public int index;
     public String config;
@@ -35,7 +37,47 @@ public class ConfigStringMessage extends ServerMessage {
 
     @Override
     public String toString() {
-        return "ConfigStringMessage{" + index + "=" + config + '}';
+        return "ConfigStringMessage{" + getType(index) + "(" + index + ")" + "=" + config + '}';
+    }
+
+    public String getType(int index) {
+        if (index == CS_NAME) {
+            return "CS_NAME";
+        } else if (index == CS_CDTRACK) {
+            return "CS_CDTRACK";
+        } else if (index == CS_SKY) {
+            return "CS_SKY";
+        } else if (index == CS_SKYAXIS) {
+            return "CS_SKYAXIS";
+        } else if (index == CS_SKYROTATE) {
+            return "CS_SKYROTATE";
+        } else if (index == CS_STATUSBAR) {
+            return "CS_STATUSBAR";
+            // fixme: what is between CS_STATUSBAR(5) and CS_AIRACCEL(29)?
+        } else if (index == CS_AIRACCEL) {
+            return "CS_AIRACCEL";
+        } else if (index == CS_MAXCLIENTS) {
+            return "CS_MAXCLIENTS";
+        } else if (index == CS_MAPCHECKSUM) {
+            return "CS_MAPCHECKSUM";
+        } else if (index < CS_SOUNDS) {
+            return "CS_MODELS";
+        } else if (index < CS_IMAGES) {
+            return "CS_SOUNDS";
+        } else if (index < CS_LIGHTS) {
+            return "CS_IMAGES";
+        } else if (index < CS_ITEMS) {
+            return "CS_LIGHTS";
+        } else if (index < CS_PLAYERSKINS) {
+            return "CS_ITEMS";
+        } else if (index < CS_GENERAL) {
+            return "CS_PLAYERSKINS";
+        } else if (index < MAX_CONFIGSTRINGS) {
+            return "CS_GENERAL";
+        } else {
+            // todo: validate
+            return "UNKNOWN";
+        }
     }
 
     @Override

--- a/server/src/main/java/jake2/server/GameImportsImpl.java
+++ b/server/src/main/java/jake2/server/GameImportsImpl.java
@@ -88,6 +88,13 @@ public class GameImportsImpl implements GameImports {
 
         // create local server state
         sv = new server_t();
+        sv.loadgame = changeMapInfo.isLoadgame;
+        sv.isDemo = changeMapInfo.isDemo;
+        sv.name = changeMapInfo.mapName;
+        sv.time = 1000;
+
+        // archive server state to be used in savegame
+        mapcmd = changeMapInfo.levelString;
 
         world = new SV_WORLD();
         cm = new CM();

--- a/server/src/main/java/jake2/server/GameImportsImpl.java
+++ b/server/src/main/java/jake2/server/GameImportsImpl.java
@@ -138,11 +138,6 @@ public class GameImportsImpl implements GameImports {
 
     @Override
     public void centerprintf(edict_t ent, String s) {
-
-        int n = ent.index;
-        if (n < 1 || n > sv_game.gameImports.serverMain.getClients().size())
-            return; // Com_Error (ERR_DROP, "centerprintf to a non-client");
-
         sv_game.PF_Unicast(ent.index, true, new PrintCenterMessage(s));
     }
 

--- a/server/src/main/java/jake2/server/GameImportsImpl.java
+++ b/server/src/main/java/jake2/server/GameImportsImpl.java
@@ -78,7 +78,7 @@ public class GameImportsImpl implements GameImports {
 
     final float[] origin_v = { 0, 0, 0 };
 
-    public GameImportsImpl(JakeServer serverMain) {
+    public GameImportsImpl(JakeServer serverMain, ChangeMapInfo changeMapInfo) {
         this.serverMain = serverMain;
 
         spawncount = Lib.rand();

--- a/server/src/main/java/jake2/server/SV_ENTS.java
+++ b/server/src/main/java/jake2/server/SV_ENTS.java
@@ -43,7 +43,7 @@ public class SV_ENTS {
 
     public final byte[] fatpvs; // 32767 is MAX_MAP_LEAFS
 
-    private final int num_client_entities; // maxclients->value*UPDATE_BACKUP*MAX_PACKET_ENTITIES
+    private final int maxClientEntities; // maxclients->value*UPDATE_BACKUP*MAX_PACKET_ENTITIES
     private final entity_state_t[] client_entities; // [num_client_entities]
     private int next_client_entities; // next client_entity to use
 
@@ -52,10 +52,10 @@ public class SV_ENTS {
         fatpvs = new byte[65536 / 8];
         this.gameImports = gameImports;
 
-        num_client_entities = clientEntitiesMax;
+        maxClientEntities = clientEntitiesMax;
 
         // Clear all client entity states
-        client_entities = new entity_state_t[num_client_entities];
+        client_entities = new entity_state_t[maxClientEntities];
         for (int n = 0; n < client_entities.length; n++) {
             client_entities[n] = new entity_state_t(null);
         }
@@ -166,7 +166,7 @@ public class SV_ENTS {
                 // does not exist in the frame
                 newnum = 9999;
             } else {
-                newState = client_entities[(currentFrame.first_entity + newindex) % this.num_client_entities];
+                newState = client_entities[(currentFrame.first_entity + newindex) % this.maxClientEntities];
                 newnum = newState.number;
             }
             final int oldnum;
@@ -174,18 +174,18 @@ public class SV_ENTS {
                 // does not exist in the frame
                 oldnum = 9999;
             else {
-                oldState = client_entities[(lastReceivedFrame.first_entity + oldindex) % this.num_client_entities];
+                oldState = client_entities[(lastReceivedFrame.first_entity + oldindex) % this.maxClientEntities];
                 oldnum = oldState.number;
             }
 
             if (newnum == oldnum) {
-                // delta update from old position
+                // delta update from old position.
                 // because the force parm is false, this will not result
-                // in any bytes being emited if the entity has not changed at
-                // all note that players are always 'newentities', this updates
-                // their oldorigin always
-                // and prevents warping
-                result.updates.add(new EntityUpdate(oldState, newState, false, newState.number <= gameImports.serverMain.getClients().size()));
+                // in any bytes being emited if the entity has not changed at all.
+                // Note: players are always 'newentities', this updates
+                // their oldorigin always  and prevents warping
+                final boolean isPlayer = newState.number <= gameImports.serverMain.getClients().size();
+                result.updates.add(new EntityUpdate(oldState, newState, false, isPlayer));
                 oldindex++;
                 newindex++;
             } else if (newnum < oldnum) {
@@ -362,7 +362,7 @@ public class SV_ENTS {
             }
 
             // add it to the circular client_entities array
-            int ix = next_client_entities % num_client_entities;
+            int ix = next_client_entities % maxClientEntities;
             entity_state_t state = client_entities[ix];
             if (ent.s.number != e) {
                 Com.DPrintf("FIXING ENT.S.NUMBER!!!\n");

--- a/server/src/main/java/jake2/server/SV_GAME.java
+++ b/server/src/main/java/jake2/server/SV_GAME.java
@@ -44,12 +44,12 @@ public class SV_GAME {
      * 
      * Sends the contents of the mutlicast buffer to a single client.
      */
-    public void PF_Unicast(int p, boolean reliable, NetworkMessage msg) {
+    public void PF_Unicast(int index, boolean reliable, NetworkMessage msg) {
 
-        if (p < 1 || p > gameImports.serverMain.getClients().size())
+        if (index < 1 || index > gameImports.serverMain.getClients().size())
             return;
 
-        client_t client = gameImports.serverMain.getClients().get(p - 1);
+        client_t client = gameImports.serverMain.getClients().get(index - 1);
 
         if (reliable) {
             client.netchan.reliablePending.add(msg);

--- a/server/src/main/java/jake2/server/SV_MAIN.java
+++ b/server/src/main/java/jake2/server/SV_MAIN.java
@@ -970,6 +970,10 @@ public class SV_MAIN implements JakeServer {
      * Only called at quake2.exe startup, not for each game
      */
     public SV_MAIN() {
+
+        // long gone
+        SV_MAIN.master_adr[0] = netadr_t.fromString("192.246.40.37", Defines.PORT_MASTER);
+
         for (int n = 0; n < Defines.MAX_CHALLENGES; n++) {
             challenges[n] = new challenge_t();
         }
@@ -1047,9 +1051,9 @@ public class SV_MAIN implements JakeServer {
      *
      * A brand new game has been started.
      */
-    GameImportsImpl createGameInstance() {
+    GameImportsImpl createGameInstance(ChangeMapInfo changeMapInfo) {
 
-        GameImportsImpl gameImports = new GameImportsImpl(this);
+        GameImportsImpl gameImports = new GameImportsImpl(this, changeMapInfo);
         gameImports.gameExports = createGameModInstance(gameImports);
         // why? should have default values already
         // fixme should not recreate all the clients
@@ -1256,10 +1260,8 @@ goes to map jail.bsp.
             boolean multiplayer = initializeServerCvars();
             // init network stuff
             NET.Config(multiplayer);
-            // long gone
-            SV_MAIN.master_adr[0] = netadr_t.fromString("192.246.40.37", Defines.PORT_MASTER);
 
-            gameImports = createGameInstance(); // the game is just starting
+            gameImports = createGameInstance(changeMapInfo); // the game is just starting
         }
 
         if (changeMapInfo.isLoadgame) {
@@ -1375,7 +1377,6 @@ For development work
 ==================
 */
     void SV_Map_f(List<String> args) {
-        String mapName;
         //char expanded[MAX_QPATH];
         if (args.size() < 2) {
             Com.Printf("usage: map <map_name>\n");
@@ -1383,7 +1384,7 @@ For development work
         }
 
         // if not a pcx, demo, or cinematic, check to make sure the level exists
-        mapName = args.get(1);
+        String mapName = args.get(1);
         if (!mapName.contains(".")) {
             String mapPath = "maps/" + mapName + ".bsp";
             if (FS.LoadFile(mapPath) == null) {

--- a/server/src/main/java/jake2/server/SV_USER.java
+++ b/server/src/main/java/jake2/server/SV_USER.java
@@ -90,11 +90,11 @@ class SV_USER {
         // send the serverdata
         // send full levelname
 
-        final int playernum;
+        final int clientIndex;
         if (gameImports.sv.state == ServerStates.SS_CINEMATIC || gameImports.sv.state == ServerStates.SS_PIC)
-            playernum = -1;
+            clientIndex = -1;
         else
-            playernum = client.edict.index - 1;
+            clientIndex = client.edict.index - 1;
 
 
         client.netchan.reliablePending.add(
@@ -103,7 +103,7 @@ class SV_USER {
                         gameImports.spawncount,
                         gameImports.sv.isDemo,
                         gamedir,
-                        playernum,
+                        clientIndex,
                         gameImports.sv.configstrings[Defines.CS_NAME]
                 ));
         //
@@ -111,8 +111,8 @@ class SV_USER {
         // 
         if (gameImports.sv.state == ServerStates.SS_GAME) {
             // set up the entity for the client
-            edict_t ent = gameImports.gameExports.getEdict(playernum + 1);
-            ent.s.number = playernum + 1;
+            edict_t ent = gameImports.gameExports.getEdict(clientIndex + 1);
+            ent.s.number = clientIndex + 1;
             client.edict = ent;
             client.lastcmd = new usercmd_t();
 


### PR DESCRIPTION
Do not reuse the same instance of GameImports/GameExports between maps

Also fixed:
+ Config string type description
+ fixed serverMain.clients usage
+ Add network logging 