### PR TITLE
Improve jake2 native library path and basedir detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Jake2 README
 Jake2 is a port of the GPL'd Quake2 engine from id Software to Java. Jake2 is
 distributed under the terms of the GPL (see LICENSE).
 
-The port is implemented completely in Java. No native libraries are used for the
-game functionality. We use the lwjgl2 for graphics rendering and for sound.
+The port is implemented in Java, but some native libraries (LWJGL) are used for the
+visual rendering, input processing and audio playback (OpenAL) functionality. 
 
 Jake2 is still under development. Feel free to send bug report if you find one.
 
@@ -17,9 +17,9 @@ Currently, Jake2 supports every Java supported platform.
 
 Requirements:
 
- * at least JDK 1.8 to build and run Jake2
+ * jdk version 11 to build and run Jake2
 
-Please note that there is an issue with more recent java versions on linux with lwjgl natives.
+Please note that there is an issue with more recent java versions (17) on linux with lwjgl natives.
 
 
 Documentation & Info
@@ -28,14 +28,14 @@ Documentation & Info
  * [BSP file format](info/BSP.md)
  * [Networking](info/Networking.md)
 
-Installation
-------------
+Installation and running
+------------------------
 
 from binary distribution:
 
 - unzip the distribution(jake2-some_version.zip)
-- go to bin folder
-- run jake2 (or jake2.bat on windows)
+- go to `bin` folder
+- run `./fullgame` (or `fullgame.bat` on windows)
 
 build from source:
 
@@ -44,16 +44,17 @@ build from source:
 
 If you don't have a gradle distribution you can use gradle wrapper, like `./gradlew run`.
 
+If you run jake from an IDE:
+  1. add dependency to `gradle installDist` task before launch
+  2. add `-Djava.library.path` VM option to point to the location of native libs (they are copied to the `fullgame/build/install/fullgame` after the task mentioned above)
+
 Installation of Quake2 data:
 ----------------------------
 
-The easiest way to run quake is to pass basedir parameter to the game
+Jake can autodetect steam installation.
+If it doesn't (when you have a non-steam version or when you install it to a custom location) pass basedir parameter to the game
 
-`+set basedir "/home/daniil/.local/share/Steam/steamapps/common/Quake 2"`
-
-If Jake2 does not detect the Quake2 files on startup you have the choice
-to select a baseq2 directory of a Quake2 installation (demo or full version)
-or to download and install the Quake2 demo files
+`+set basedir "/home/demoth/.local/share/Steam/steamapps/common/Quake 2"`
 
 If you want to have the latest experimental features you can grab the latest
 Jake2 sources from GIT.
@@ -64,6 +65,8 @@ Compatibility
 Jake2 is not compatible with the mods that have custom logic (game.dll).
 
 Jake2 is network compatible with other clients, like Yamagi, Q2pro etc.
+
+Jake2 is compatible with all map/models/sounds/textures as id Quake 2.
 
 Goals of the project
 --------------------

--- a/client/src/main/java/jake2/client/render/fast/Image.java
+++ b/client/src/main/java/jake2/client/render/fast/Image.java
@@ -1567,8 +1567,9 @@ public abstract class Image extends Main {
 
 		LoadPCX("pics/colormap.pcx", palette, null);
 
-		if (palette[0] == null || palette[0].length != 768)
-			Com.Error(Defines.ERR_FATAL, "Couldn't load pics/colormap.pcx");
+		if (palette[0] == null || palette[0].length != 768) {
+			Com.Error(Defines.ERR_FATAL, "Couldn't load pics/colormap.pcx, probably `basedir` is set incorrectly");
+		}
 
 		byte[] pal = palette[0];
 

--- a/fullgame/build.gradle.kts
+++ b/fullgame/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 
 application {
     mainClass.set("jake2.fullgame.Jake2")
-    // added to start script
-    applicationDefaultJvmArgs = listOf("-Djava.library.path=..")
+    // add library path for both cases: when we run from a shell script or from `gradle run`
+    applicationDefaultJvmArgs = listOf("-Djava.library.path=..:./build/install/fullgame/")
 
 
     distributions {
@@ -70,4 +70,4 @@ task("copyNatives") {
 tasks["installDist"].dependsOn("copyNatives")
 tasks["distZip"].dependsOn("copyNatives")
 tasks["distTar"].dependsOn("copyNatives")
-tasks["run"].dependsOn("copyNatives")
+tasks["run"].dependsOn("installDist")

--- a/fullgame/src/main/java/jake2/fullgame/Jake2.java
+++ b/fullgame/src/main/java/jake2/fullgame/Jake2.java
@@ -64,7 +64,16 @@ public final class Jake2 {
      * @param args
      */
     public static void main(String[] args) {
-    	
+
+        final String libPath = "java.library.path";
+        System.out.println(libPath + "=" + System.getProperty(libPath));
+
+        final String lwjglPath = "org.lwjgl.librarypath";
+        System.out.println(lwjglPath + "=" + System.getProperty(lwjglPath));
+
+        final String currentDir = System.getProperty("user.dir");
+        System.out.println("working directory=" + currentDir);
+
     	boolean dedicated = false;
 
     	// check if we are in dedicated mode to hide the java dialog.

--- a/qcommon/src/main/java/jake2/qcommon/filesystem/FS.java
+++ b/qcommon/src/main/java/jake2/qcommon/filesystem/FS.java
@@ -39,6 +39,7 @@ import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
+import java.nio.file.Paths;
 import java.util.*;
 
 /*
@@ -781,7 +782,12 @@ public final class FS extends Globals {
         // basedir <path>
         // allows the game to run from outside the data tree
         //
-        fs_basedir = Cvar.getInstance().Get("basedir", ".", CVAR_NOSET);
+        if (new File("./baseq2").exists()) {
+            fs_basedir = Cvar.getInstance().Get("basedir", ".", CVAR_NOSET);
+        } else {
+            var autoDetectedBasedir = autodetectBasedir();
+            fs_basedir = Cvar.getInstance().Get("basedir", autoDetectedBasedir, CVAR_NOSET);
+        }
 
         //
         // cddir <path>
@@ -801,6 +807,42 @@ public final class FS extends Globals {
 
         if (!fs_gamedirvar.string.isEmpty())
             SetGamedir(fs_gamedirvar.string);
+    }
+
+    private static String autodetectBasedir() {
+        // linux
+        var home = System.getProperty("user.home");
+        if (home != null && !home.isBlank()) {
+            var steamLinuxPath = Paths.get(home, ".steam", "steam", "steamapps", "common", "Quake 2").toFile();
+            if (steamLinuxPath.exists()) {
+                System.out.println("Auto-detected steam q2 installation at :" + steamLinuxPath);
+                return steamLinuxPath.getAbsolutePath();
+            }
+
+            // Mac
+            var macSteamPath = Paths.get(home, "Library", "Application Support", "Steam", "steamapps", "common", "Quake 2").toFile();
+            if (macSteamPath.exists()) {
+                System.out.println("Auto-detected steam q2 installation at :" + macSteamPath);
+                return macSteamPath.getAbsolutePath();
+            }
+        }
+
+        // windows 32
+        var windowsProgramFiles = Paths.get("c:", "Program Files (x86)", "Steam", "steamapps", "common", "Quake 2").toFile();
+        if (windowsProgramFiles.exists()) {
+            System.out.println("Auto-detected steam q2 installation at :" + windowsProgramFiles);
+            return windowsProgramFiles.getAbsolutePath();
+        }
+
+        // windows 64
+        var windowsProgramFiles64 = Paths.get("c:", "Program Files", "Steam", "steamapps", "common", "Quake 2").toFile();
+        if (windowsProgramFiles64.exists()) {
+            System.out.println("Auto-detected steam q2 installation at :" + windowsProgramFiles64);
+            return windowsProgramFiles64.getAbsolutePath();
+        }
+
+
+        return ".";
     }
 
     /**


### PR DESCRIPTION
fix some sections or readme related to installation; 

fix library path for `gradle run`

add auto-detection of steam installation,

address #101 and #102