### PR TITLE
Fix Gradle 9 deprecations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,10 @@ buildscript {
 configure(subprojects) {
   apply plugin: 'java-library'
   apply plugin: 'kotlin'
-  sourceCompatibility = 11
+  java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+  }
   compileJava {
     options.incremental = true
   }

--- a/cake/lwjgl3/build.gradle
+++ b/cake/lwjgl3/build.gradle
@@ -23,8 +23,10 @@ else {
 }
 
 sourceSets.main.resources.srcDirs += [ rootProject.file('assets').path ]
-mainClassName = 'org.demoth.cake.lwjgl3.Lwjgl3GameLauncher'
-application.setMainClass(mainClassName)
+def mainClassName = 'org.demoth.cake.lwjgl3.Lwjgl3GameLauncher'
+application {
+  mainClass.set(mainClassName)
+}
 java.sourceCompatibility = 11
 java.targetCompatibility = 11
 
@@ -62,7 +64,7 @@ jar {
   }
 // setting the manifest makes the JAR runnable.
   manifest {
-    attributes 'Main-Class': project.mainClassName
+    attributes 'Main-Class': mainClassName
   }
 // this last step may help on some OSes that need extra instruction to make runnable JARs.
   doLast {

--- a/cake/lwjgl3/nativeimage.gradle
+++ b/cake/lwjgl3/nativeimage.gradle
@@ -9,7 +9,7 @@ project(":cake:lwjgl3") {
     binaries {
       main {
         imageName = appName
-        mainClass.set(mainClassName)
+        mainClass.set('org.demoth.cake.lwjgl3.Lwjgl3GameLauncher')
         requiredVersion = '23.0'
         buildArgs.add("-march=compatibility")
         jvmArgs.addAll("-Dfile.encoding=UTF8")

--- a/cake/lwjgl3/nativeimage.gradle
+++ b/cake/lwjgl3/nativeimage.gradle
@@ -9,7 +9,7 @@ project(":cake:lwjgl3") {
     binaries {
       main {
         imageName = appName
-        mainClass = project.mainClassName
+        mainClass.set(mainClassName)
         requiredVersion = '23.0'
         buildArgs.add("-march=compatibility")
         jvmArgs.addAll("-Dfile.encoding=UTF8")


### PR DESCRIPTION
## Summary
- switch to `java` plugin extension instead of deprecated `JavaPluginConvention`
- stop using `mainClassName` property and update manifest/native image config

## Testing
- `./gradlew help --warning-mode all`

------
https://chatgpt.com/codex/tasks/task_e_6848a11b54208329ad9e06152981c463